### PR TITLE
Fix for #211 (Str 1 can't be rolled)

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -698,6 +698,10 @@ export async function roll_trait(message, trait_dice, dice_label, html, extra_da
     let trait_rolls = [];
     let dice = [];
     let roll_string = `1d${trait_dice.die.sides}x`
+    // @zk-sn: If roll is a 1d1x (example: Strength score of 1), change it to 1d1 to prevent exploding die recursion.  (Fix for #211)
+    if (roll_string === `1d1x`) {
+	roll_string = `1d1`;    
+    }
     for (let i = 0; i < (rof - 1); i++) {
         roll_string += `+1d${trait_dice.die.sides}x`
     }

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -851,8 +851,13 @@ export async function roll_dmg(message, html, expend_bennie, default_options, ra
     }
     for (let target of targets) {
         let current_damage_roll = JSON.parse(JSON.stringify(damage_roll))
-        let roll = new Roll(raise ? formula + raise_formula : formula,
-            actor.getRollShortcuts());
+        // @zk-sn: If strength is 1, make @str not explode: fix for #211 (Str 1 can't be rolled)
+        // let roll = new Roll(raise ? formula + raise_formula : formula, actor.getRollShortcuts());
+        let shortcuts = actor.getRollShortcuts();
+        if (shortcuts.str === "1d1x[Strength]") {
+            shortcuts.str = "1d1[Strength]";
+        }
+        let roll = new Roll(raise ? formula + raise_formula : formula, shortcuts);
         roll.evaluate();
         const defense_values = get_tougness_targeted_selected(actor, target);
         current_damage_roll.brswroll.rolls.push(


### PR DESCRIPTION
Update cards_common.js to override if a trait roll is 1d1x, change it to 1d1
Update item_cards.js to override the @str shortcut if strength is 1, to change it from "1d1x[Strength]" to "1d1[Strength]"
This will prevent the error causing recursion in exploding dice.