### PR TITLE
Fix for #260, prevent trait-less items from throwing an error

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -150,7 +150,7 @@ export function create_render_options(actor, render_data) {
     render_data.collapse_results = ! (game.settings.get('betterrolls-swade2', 'expand-results'))
     render_data.collapse_rolls = ! (game.settings.get('betterrolls-swade2', 'expand-rolls'));
     // Retrieve object from ids.
-    if (render_data.hasOwnProperty('trait_id')) {
+    if (render_data.hasOwnProperty('trait_id') && render_data.trait_id !== "") {
         let trait;
         if (render_data.trait_id.hasOwnProperty('name')) {
             // This is an atribute

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -120,7 +120,7 @@ async function create_item_card(origin, item_id, collapse_actions) {
     let message = await create_common_card(origin,
         {header: {type: 'Item', title: item.name,
             img: item.img}, notes: notes,  footer: footer, damage: damage,
-            trait_id: trait.id || trait, ammo: ammo,
+            trait_id: (trait !== undefined) ? trait.id : "", ammo: ammo,
             subtract_selected: subtract_select, subtract_pp: subtract_pp_select,
             trait_roll: trait_roll, damage_rolls: [],
             powerpoints: power_points, action_groups: action_groups, used_shots: 0,


### PR DESCRIPTION
There's neater ways of building the contents of `render_data` than this, but this was the smallest possible change that resolves the issue. Let me know if you'd prefer a larger change that's perhaps a bit neater.