### PR TITLE
Arcane Devices support

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -373,7 +373,7 @@ export function get_item_trait(item, actor) {
     // Now check if there is something in the Arcane field
     // noinspection JSUnresolvedVariable
     if (item.data.data.arcane) {
-        return skill_from_string(actor, item.data.data.arcane);
+        return trait_from_string(actor, item.data.data.arcane);
     }
     // If there is no skill anyway we are left to guessing
     let skill;
@@ -472,7 +472,7 @@ async function discount_ammo(item, rof, shot_override) {
 }
 
 /**
- * Discount pps from an actor
+ * Discount pps from an actor (c) Javier or Arcane Device (c) Salieri
  *
  * @param {SwadeActor }actor
  * @param item
@@ -488,7 +488,16 @@ async function discount_pp(actor, item, rolls) {
     const pp = success ? parseInt(item.data.data.pp) : 1;
     // noinspection JSUnresolvedVariable
     let current_pp;
-    if (actor.data.data.powerPoints.hasOwnProperty(item.data.data.arcane)) {
+    // If devicePP is found, it will be treated as an Arcane Device:
+    let arcaneDevice = false;
+    if (item.data.data.additionalStats.devicePP) {
+        // Get the devices PP:
+        current_pp = item.data.data.additionalStats.devicePP.value;
+        arcaneDevice = true;
+    }
+    // Do the rest only if it is not an Arcane Device and ALSO only use the tabs PP if it has a value:
+    else if (actor.data.data.powerPoints.hasOwnProperty(item.data.data.arcane)   
+    && actor.data.data.powerPoints[item.data.data.arcane].max) {
         // Specific power points
         current_pp = actor.data.data.powerPoints[item.data.data.arcane].value;
     } else {
@@ -502,13 +511,23 @@ async function discount_pp(actor, item, rolls) {
         content = game.i18n.localize("BRSW.NotEnoughPP") +  content;
     }
     let data = {}
-    if (actor.data.data.powerPoints.hasOwnProperty(item.data.data.arcane)) {
+    if (arcaneDevice === true) {
+        const updates = [
+            { _id: item.id, "data.additionalStats.devicePP.value": `${final_pp}` },
+          ];
+          // Updating the Arcane Device:
+          actor.updateOwnedItem(updates);
+    }
+    else if (actor.data.data.powerPoints.hasOwnProperty(item.data.data.arcane)
+    && actor.data.data.powerPoints[item.data.data.arcane].max) {
         data['data.powerPoints.' + item.data.data.arcane + '.value'] =
             final_pp;
     } else {
         data['data.powerPoints.value'] = final_pp;
     }
-    await actor.update(data);
+    if (arcaneDevice === false) {
+        await actor.update(data);
+    }
     await ChatMessage.create({
         content: content
     });

--- a/docs/card_types.md
+++ b/docs/card_types.md
@@ -57,9 +57,14 @@ Power cards are very similar to ranged weapons (if they have damaging effects).
 
 ![Power Card](img/power_card_v1-119.jpg)
 
-Available global actions are "Subtract Power points" - can be activated in the settings as default and "Manual PP management". The automatic solution will always deduct the base amount defined in the power. With the second option you can manually either expend or recharge Power Points
+Available global actions are "Subtract Power points" - can be activated in the settings as default and "Manual PP management". The automatic solution will always deduct the base amount defined in the power. With the second option you can manually either expend or recharge Power Points.  
 
-![Power Point Management](img/power_point_management_v1-119.jpg)
+![Power Point Management](img/power_point_management_v1-119.jpg)  
+  
+### Arcane Devices (by SalieriC)  
+The automated PP Management also supports Arcane Devices created with the Artificier Edge, this however requires you to set up an Additional Stat. Head to the System configuration and set up a new Additional Stat for items. The `Stat Key` *must* be exactly this: `devicePP`  
+The name doesn't matter, data type is `Number` and also check the checkbox "Has Max Value".  
+From now on you can make any power an Arcane Device by activating the Additional Stat you've just created on the power. If that Additional Stat is activated, the script will automatically detect it as an Arcane Device and use the Power Points stored on the Power itself, not the ones of the character.  
 
 # Soak Rolls
 


### PR DESCRIPTION
Support for "Arcane Devices", created by the Artificier Edge, that uses Power Points stored on the Power itself instead of the characters PP.
Tested and working. Requires the use of systems Additional Stats, detailed in the documentation.