### PR TITLE
More robust options for displaying remaining pp or ammo chat card

### DIFF
--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -267,6 +267,7 @@
     "BRSW.EdgeName-MartialWarrior": "Martial Warrior",
     "BRSW.None" : "No one",
     "BRSW.MasterOnly": "Master only",
+    "BRSW.MasterAndGM": "Master and GM",
     "BRSW.RemainingBehaviour": "Who can see the PP and ammo remaining card",
     "BRSW.RemainingBehaviour_hint": "Select who (if anybody) can see the card informing of the used and remaining shots and PP"
 }

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -397,6 +397,7 @@ function register_settings_version2() {
         choices: {
             none: game.i18n.localize('BRSW.None'),
             master_only: game.i18n.localize('BRSW.MasterOnly'),
+            master_and_gm: game.i18n.localize('BRSW.MasterAndGM'),
             everybody: game.i18n.localize("BRSW.Everybody")
         },
         config: true

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -191,7 +191,7 @@ export async function spend_bennie(actor){
     } else {
         await spendMastersBenny();
         if (game.dice3d) {
-            const benny = new Roll('1dB').roll();
+            const benny = new Roll('1dB').roll({async:false});
             // noinspection JSIgnoredPromiseFromCall,ES6MissingAwait
             game.dice3d.showForRoll(benny, game.user, true, null, false);
         }


### PR DESCRIPTION
Can now be everyone, no one, master only or gm and master.
Fixed typo
Update `actor.updateOwnedItem(updates);` fully deprecated in Foundry v9 to `actor.updateEmbeddedDocuments("Item", updates);`