### PR TITLE
add attacker bonus from formation fighter

### DIFF
--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -403,6 +403,9 @@ function calculate_gangUp(attacker, target) {
             t.actor?.items.find(item => {return item.data.name.toLowerCase().includes(formation_fighter_name)})
         );
         enemies = allies_within_range_of_target.length + allies_with_formation_fighter.length;
+        if (enemies > 0 && attacker.actor?.items.find(item => {return item.data.name.toLowerCase().includes(formation_fighter_name)})) {
+            enemies = enemies + 1;
+        }
         // allies with formation fighter are counted twice
         allies = enemies_within_range_both_attacker_target.length;
     }


### PR DESCRIPTION
A character with Formation Fighter (SWPF) applies +1 to "herself and
her allies". Per Clint's clarification (linked below) this +1 also
applies with the attacker is the only one with Formation Fighter.

https://www.pegforum.com/forum/pathfinder-for-savage-worlds/official-answers-on-pathfinder-for-savage-worlds/55491-formation-fighter-clarification