### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/betterrolls-swade2/lang/ca.json
+++ b/betterrolls-swade2/lang/ca.json
@@ -311,5 +311,9 @@
     "BRSW.Auto-status-cardsHint": "Mostra la carta per eliminar l'estat (actualment només atordit) a l'inici del combat",
     "BRSW.UnshakeFailure": "{name} ha fallat la tirada d'esperit per eliminar l'atordit.",
     "BRSW.GlobalTab": "Global",
-    "BRSW.CharacterTab": "Personatge"
+    "BRSW.CharacterTab": "Personatge",
+    "BRSW.NoRollRequired": "No cal fer cap tirada d'habilitat!",
+    "BRSW.IlluminationGM": "Il·luminació (DJ)",
+    "BRSW.none": "Cap",
+    "BRSW.undeadIgnoresIlluminationHint": "Si està marcada, l'habilitat especial de no-morts també ignorarà les penalitzacions d'il·luminació de fins a 10 polzades. S'utilitza a Pathfinder per a Savage Worlds."
 }

--- a/betterrolls-swade2/lang/es.json
+++ b/betterrolls-swade2/lang/es.json
@@ -310,6 +310,10 @@
     "BRSW.MasterModifiers": "Modificadores GM",
     "BRSW.StreamTemplate": "Plantilla de emanación",
     "BRSW.CharacterTab": "Personaje",
-    "BRSW.GlobalTab": "Global"
-
+    "BRSW.GlobalTab": "Global",
+    "BRSW.none": "Ninguna",
+    "BRSW.IlluminationGM": "Iluminación (GM)",
+    "BRSW.NoRollRequired": "¡No se necesita una tirada de habilidad!",
+    "BRSW.undeadIgnoresIllumination": "Los no muertos ignoran las penalizaciones por iluminación",
+    "BRSW.undeadIgnoresIlluminationHint": "Si se comprueba, la habilidad especial de los muertos vivientes también ignorará las penalizaciones por iluminación durante un máximo de 10''. Esto se utiliza en Pathfinder para Savage Worlds."
 }


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [Better Rolls for SWADE/main](https://weblate.foundryvtt-hub.com/projects/betterrolls-swade2/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widgets/betterrolls-swade2/-/main/horizontal-auto.svg)