### PR TITLE
Fixed a bug in damage mod calculation

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -180,8 +180,7 @@ export class BrCommonCard {
                 this.extra_text += global_action.extra_text
             }
             if (!this.action_groups.hasOwnProperty(group_name_id)) {
-                const translated_group = group_name.slice(0, 5) === 'BRSW.' ?
-                    game.i18n.localize(group_name) : group_name
+                const translated_group = game.i18n.localize(group_name)
                 this.action_groups[group_name_id] = {
                     name: translated_group, actions: [], id: broofa(),
                     collapsed: game.settings.get('betterrolls-swade2', 'collapse-modifiers')}
@@ -1555,13 +1554,13 @@ async function duplicate_message(message, event) {
 export function create_modifier(label, expression) {
     let modifier = {name: label, value: 0, extra_class: '', dice: null}
     if (isNaN(expression)) {
-        if (expression.indexOf('d')) {
+        if (expression.indexOf('d') > 0) {
             // This is a die expression
             modifier.dice = new Roll(expression)
             modifier.dice.evaluate({async:false})
             modifier.value = parseInt(modifier.dice.result)
         } else {
-            modifier.value = parseInt(expression)
+            modifier.value = eval(expression)
         }
     } else {
         modifier.value = parseInt(expression)


### PR DESCRIPTION
The code wasn't handling the case of multiple modifiers. I found the bug when I had a weapon with a modifier and that weapon had a Smite effect on it. The resulting expression was "+2+4".

The first issue was that indexOf wasn't checking for > 0 so it was actually only ever not going into that block if d was the first character. The second issue was there was nothing that would convert something like "+2+4" into a valid output. I added the eval function there instead of parseInt.