### PR TITLE
Changed sort for AEs and item actions to use the name instead of the ID

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -249,6 +249,9 @@ export class BrCommonCard {
     this.populate_active_effect_actions();
     for (const group in this.action_groups) {
       this.action_groups[group].actions.sort((a, b) => {
+        if (group == 'Active effects' || group == 'Item actions') {
+          return a.code.name > b.code.name ? 1 : -1;
+        }
         return a.code.id > b.code.id ? 1 : -1;
       });
     }


### PR DESCRIPTION
Since active effects and item actions both use generated GUIDs as their IDs, using them to sort creates arbitrary sort orders.