### PR TITLE
Update trait on card when action uses skill override.

### DIFF
--- a/betterrolls-swade2/scripts/card-dialog.js
+++ b/betterrolls-swade2/scripts/card-dialog.js
@@ -78,6 +78,9 @@ class BrCardDialog {
       enabled_actions.push(button.dataset.actionId);
     }
     this.BrCard.set_active_actions(enabled_actions);
+    
+    this.BrCard.set_trait_using_skill_override(active_actions);
+
     await this.BrCard.render();
     await this.BrCard.save();
     this.close_card();

--- a/betterrolls-swade2/scripts/card-dialog.js
+++ b/betterrolls-swade2/scripts/card-dialog.js
@@ -78,8 +78,7 @@ class BrCardDialog {
       enabled_actions.push(button.dataset.actionId);
     }
     this.BrCard.set_active_actions(enabled_actions);
-    
-    this.BrCard.set_trait_using_skill_override(active_actions);
+    this.BrCard.set_trait_using_skill_override();
 
     await this.BrCard.render();
     await this.BrCard.save();

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -408,7 +408,6 @@ export class BrCommonCard {
   set_trait_using_skill_override() {
     const actions = this.get_selected_actions();
 
-    this.render_data.type
     const action = actions.find( 
       a => a.code.hasOwnProperty('skillOverride') && a.code.skillOverride != "");
 

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -408,20 +408,28 @@ export class BrCommonCard {
   set_trait_using_skill_override() {
     const actions = this.get_selected_actions();
 
+    this.render_data.type
     const action = actions.find( 
       a => a.code.hasOwnProperty('skillOverride') && a.code.skillOverride != "");
 
     if (!actor || !action) return;
 
     this.reset_default_trait();
-    const skill_swid = game.swade.util.slugify(action?.code.skillOverride, 'skill');
-    const skill = this.actor.getSingleItemBySwid(skill_swid);
+    const skill_swid = game.swade.util.slugify(action?.code.skillOverride);
+    const skill = this.actor.getSingleItemBySwid(skill_swid, 'skill');
     this.render_data.trait_id = skill.id;    
   }
 
+  /**
+   * Revert the trait back to the default for the item
+   */
   reset_default_trait() {
-    const item = this.actor?.items.find( i => i.id == this.item_id);
+    const item = this.item;
 
+    if (!item) {
+      item = this.actor?.items.find( i => i.id == this.item_id);
+    }
+    
     if (item) {
       this.render_data.trait_id = get_item_trait(item, this.actor);
     }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -403,6 +403,31 @@ export class BrCommonCard {
   }
 
   /**
+   * Set the trait_id for the render_data for the
+   */
+  set_trait_using_skill_override() {
+    const actions = this.get_selected_actions();
+
+    const action = actions.find( 
+      a => a.code.hasOwnProperty('skillOverride') && a.code.skillOverride != "");
+
+    if (!actor || !action) return;
+
+    this.reset_default_trait();
+    const skill_swid = game.swade.util.slugify(action?.code.skillOverride, 'skill');
+    const skill = this.actor.getSingleItemBySwid(skill_swid);
+    this.render_data.trait_id = skill.id;    
+  }
+
+  reset_default_trait() {
+    const item = this.actor?.items.find( i => i.id == this.item_id);
+
+    if (item) {
+      this.render_data.trait_id = get_item_trait(item, this.actor);
+    }
+  }
+
+  /**
    * Creates an object to store some data in the old render_data flag.
    * @param render_data
    * @param template

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -412,7 +412,7 @@ export class BrCommonCard {
     const action = actions.find( 
       a => a.code.hasOwnProperty('skillOverride') && a.code.skillOverride != "");
 
-    if (!actor || !action) return;
+    if (!this.actor || !action) return;
     
     const skill_swid = game.swade.util.slugify(action?.code.skillOverride);
     const skill = this.actor.getSingleItemBySwid(skill_swid, 'skill');

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -408,12 +408,12 @@ export class BrCommonCard {
   set_trait_using_skill_override() {
     const actions = this.get_selected_actions();
 
+    this.reset_default_trait();
     const action = actions.find( 
       a => a.code.hasOwnProperty('skillOverride') && a.code.skillOverride != "");
 
     if (!actor || !action) return;
-
-    this.reset_default_trait();
+    
     const skill_swid = game.swade.util.slugify(action?.code.skillOverride);
     const skill = this.actor.getSingleItemBySwid(skill_swid, 'skill');
     this.render_data.trait_id = skill.id;    


### PR DESCRIPTION
Updates the trait on the card when an action is selected, like when a Dagger with a Throw action is defined.  For example, it will change Fighting d6 to Athletics d8.  Not sure if this is the correct way, but it seems to be working.