### PR TITLE
Fix component rendering when using portuguese translation

### DIFF
--- a/betterrolls-swade2/css/brsw-styles.css
+++ b/betterrolls-swade2/css/brsw-styles.css
@@ -298,7 +298,7 @@
 }
 
 .brsw-tab-content{
-    height: 8em;
+    margin-bottom: 1em;
 }
 
 #br-card-dialog {


### PR DESCRIPTION
When `pt-BR` is selected as language, the addon breaks layouts.
This PR fixes this.

<table>
<tr>
 <td>
Before
 </td>
 <td>
After
 </td>
</tr>
<tr>
 <td>
<img width="310" alt="image" src="https://github.com/javierriveracastro/betteroll-swade/assets/7375252/5326c622-dd42-486a-b6ea-245704c3b2ce">
 </td>
 <td>
<img width="309" alt="image" src="https://github.com/javierriveracastro/betteroll-swade/assets/7375252/3f899f1b-bcf7-4ad6-8f82-c36ac461a785">
 </td>
</table>

This PR doesn't affect the english version:
<table>
<tr>
 <td>
Before
 </td>
 <td>
After
 </td>
</tr>
<tr>
 <td>
<img width="299" alt="image" src="https://github.com/javierriveracastro/betteroll-swade/assets/7375252/c31a9b71-20e7-415d-a45a-f861d400313a">
 </td>
 <td>
<img width="315" alt="image" src="https://github.com/javierriveracastro/betteroll-swade/assets/7375252/e6054aaa-7e8a-42af-b607-0163fb91f2f7">
 </td>
</table>