### PR TITLE
Added an option to pop out chat cards automatically

### DIFF
--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -224,6 +224,8 @@
   "BRSW.OR.NPCDontUseEncumbrance": "Encumbrance penalties are not applied to NPCs",
   "BRSW.OR.RiftsGrittyDamage": "Mega Damage causes gritty damage",
   "BRSW.OverExtremeRange": "Over extreme range",
+  "BRSW.PopoutChat": "Auto Pop Out Chat",
+  "BRSW.PopoutChatHint": "When checked, chat cards are automatically popped out for the relevant user when they are created",
   "BRSW.PowerModifiers-": "Power Modifiers - ",
   "BRSW.PowerModifiers-P": " [+1PP]",
   "BRSW.PowerModifiersArcaneProtection": "Power Modifiers - Arcane Protection",

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -52,23 +52,27 @@ import {
 } from "./chat_modifers_names.js";
 import { setup_dialog } from "./card-dialog.js";
 
+// Init Hook
+Hooks.on(`init`, () => {
+  game.brsw = {};
+  game.brsw.get_action_from_click = get_action_from_click;
+  register_settings_version2();
+  register_actions();
+  register_gm_modifiers_settings();
+  register_gm_actions_settings();
+});
+
 // Base Hook
 Hooks.on(`ready`, () => {
   console.log("Better Rolls 2 for SWADE | Ready");
   // Create a base object to hook functions
   // noinspection JSUndefinedPropertyAssignment
-  game.brsw = {};
-  game.brsw.get_action_from_click = get_action_from_click;
   attribute_card_hooks();
   skill_card_hooks();
   expose_item_functions();
   expose_global_actions_functions();
   expose_card_class();
   incapacitation_card_hooks();
-  register_settings_version2();
-  register_actions();
-  register_gm_modifiers_settings();
-  register_gm_actions_settings();
   // Load partials.
   const templatePaths = [
     "modules/betterrolls-swade2/templates/common_card_header.html",
@@ -156,6 +160,14 @@ Hooks.on("renderChatMessage", (message, html) => {
     if (!game.user.isGM) {
       html.find(".brsw-master-only").remove();
     }
+
+    if (game.user.id == message.user.id) {
+      let popout_processed = message.getFlag("betterrolls-swade2", "popout_processed");
+      if (popout_processed != true) {
+        card.create_popout();
+      }
+    }
+
     // Scroll the chat to the bottom if this is the last message
     if (game.messages.contents[game.messages.contents.length - 1] === message) {
       let chat_bar = $("#chat-log");
@@ -585,6 +597,13 @@ function register_settings_version2() {
     hint: "BRSW.MaxTooltipLengthHint",
     type: Number,
     default: 500,
+    config: true,
+  });
+  game.settings.register("betterrolls-swade2", "auto_popout_chat", {
+    name: "BRSW.PopoutChat",
+    hint: "BRSW.PopoutChatHint",
+    default: false,
+    type: Boolean,
     config: true,
   });
 }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -121,9 +121,9 @@ export class BrCommonCard {
   }
 
   create_popout() {
+    this.message.flags["betterrolls-swade2"].popout_processed = true;
+    this.message.update({"flags": this.message.flags});
     if (game.settings.get("betterrolls-swade2", "auto_popout_chat")) {
-      this.message.flags["betterrolls-swade2"].popout_processed = true;
-      this.message.update({"flags": this.message.flags});
       new ChatPopout(this.message).render(true);
     }
   }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -63,7 +63,7 @@ export function BRWSRoll() {
  * @param {ChatMessage} message
  * @param render_object
  */
-async function store_render_flag(message, render_object) {
+function store_render_flag(message, render_object) {
   for (let property of ["actor", "skill"]) {
     delete render_object[property];
   }
@@ -71,7 +71,7 @@ async function store_render_flag(message, render_object) {
   if (message.flags?.["betterrolls-swade2"]?.render_data) {
     message.flags["betterrolls-swade2"].render_data.update_uid = broofa();
   }
-  await message.setFlag("betterrolls-swade2", "render_data", render_object);
+  message.flags["betterrolls-swade2"].render_data = render_object;
 }
 
 export class BrCommonCard {
@@ -113,13 +113,27 @@ export class BrCommonCard {
       this.update_list.id = this.message.id;
       this.message.update(this.update_list);
     }
-    await this.message.setFlag(
-      "betterrolls-swade2",
-      "br_data",
-      this.get_data(),
-    );
+    this.message.flags["betterrolls-swade2"] = {...this.message.flags["betterrolls-swade2"]};
+    this.message.flags["betterrolls-swade2"].br_data = this.get_data();
     // Temporary
-    await store_render_flag(this.message, this.render_data);
+    store_render_flag(this.message, this.render_data);
+    await this.message.update({"flags": this.message.flags});
+  }
+
+  create_popout() {
+    if (game.settings.get("betterrolls-swade2", "auto_popout_chat")) {
+      this.message.flags["betterrolls-swade2"].popout_processed = true;
+      this.message.update({"flags": this.message.flags});
+      new ChatPopout(this.message).render(true);
+    }
+  }
+
+  close_popout() {
+    for (let app of Object.values(this.message.apps)) {      
+      if (app.constructor.name === "ChatPopout") {
+        app.close();
+      }
+    }
   }
 
   /**
@@ -610,7 +624,7 @@ export class BrCommonCard {
     let whisper_data = getWhisperData();
     // noinspection JSUnresolvedVariable
     let chatData = {
-      user: game.user.id,
+      user: this.actor._idx,
       content: "<p>Default content, likely an error in Better Rolls</p>",
       speaker: {
         actor: this.actor._idx,

--- a/betterrolls-swade2/scripts/damage_card.js
+++ b/betterrolls-swade2/scripts/damage_card.js
@@ -249,6 +249,7 @@ export function activate_damage_card_listeners(message, html) {
   });
   html.find(".brsw-show-incapacitation").click(() => {
     // noinspection JSIgnoredPromiseFromCall
+    br_card.close_popout(); //We assume we're done with the card at this point so close any popouts
     create_incapacitation_card(br_card.token_id);
   });
   html.find(".brsw-injury-button").click(() => {

--- a/betterrolls-swade2/scripts/incapacitation_card.js
+++ b/betterrolls-swade2/scripts/incapacitation_card.js
@@ -125,6 +125,7 @@ export function activate_incapacitation_card_listeners(message, html) {
     .bind("click", { br_card: br_card }, roll_incapacitation_clicked);
   html.find(".brsw-injury-button").click((ev) => {
     // noinspection JSIgnoredPromiseFromCall
+    br_card.close_popout(); //We assume we're done with the card at this point so close any popouts
     create_injury_card(br_card.token_id, ev.currentTarget.dataset.injuryType);
   });
 }


### PR DESCRIPTION
First actual feature work from me. What this does is add functionality for automatically popping out chat cards when they're created. With the exception of the damage card, this happens for the user who triggered the roll. For the damage card, it pops out the window for the owner of the actor being damaged. This means that if the GM is applying damage to a player, the pop out will appear for that player. Otherwise, it appears for the GM.

Both the damage card and incap card close themselves when moving to the step e.g. when you click "Show Incapacitation card" from the damage card, the damage card closes itself before opening the incap card. This prevents a stack of windows as the player goes through each step.

Another changes you'll see in there is the addition of the init hook. I needed to do this because the calls to renderChatMessage happen before the ready hook which means that the settings hadn't been initialized yet. I tried to minimize the amount of things I moved over.

Finally, you'll see some reworking of setFlag in a few places. This was needed because each time you call setFlag on a message, it triggers another call to renderChatMessage. This chain of renders meant that we would sometimes be calling multiple at the same time and we'd end up with thread race conditions. This minimizes the number of renders and prevents the cases where we were calling multiple times on the same message in the same callstack.

I've pretty thoroughly tested this. I've had a GM and 2 other players all active at the same time and tried every combination of card that I could think of. It looks solid.

Let me know if you have any questions.