### PR TITLE
Fixing the scope on .flex

### DIFF
--- a/betterrolls-swade2/css/brsw-tw-styles.css
+++ b/betterrolls-swade2/css/brsw-tw-styles.css
@@ -116,7 +116,7 @@
   display:inline;
 }
 
-.flex {
+.brsw .flex {
   display:flex;
 }
 

--- a/betterrolls-swade2/templates/card_dialog.html
+++ b/betterrolls-swade2/templates/card_dialog.html
@@ -1,4 +1,4 @@
-<div class="z-50 overflow-y-auto h-50 max-h-full">
+<div class="brsw z-50 overflow-y-auto h-50 max-h-full">
     <div class="flex items-start justify-between p-1 border-solid border-0 border-b border-gray-600">
         <h2 class="text-xl font-semibold border-none ml-2">
             {{ BrCard.render_data.header.title }}

--- a/betterrolls-swade2/templates/common_card_header.html
+++ b/betterrolls-swade2/templates/common_card_header.html
@@ -1,23 +1,25 @@
-<div id="brc-{{ id }}" class="flex flex-row mb-1">
-    <div>
-        <img class="brws-actor-img w-8 h-8 rounded hover:ring-2 hover:ring-offset-1 hover:cursor-pointer" src="{{{actor.img}}}">
-    </div>
-    <div class="flex-grow text-center align-middle text-lg relative overflow-clip hover:overflow-visible">
-        <span class="group">
-            {{header.title}}<i class="brsw-repeat-card fas fa-redo hover:ring-2 hover:ring-offset-1 hover:cursor-pointer"></i>
-            {{# if description}}
-                <div id="tooltip-description" role="tooltip"
-                     class="w-56 opacity-0 h-0 absolute transition-opacity group-hover:visible group-hover:delay-500 group-hover:duration-500 group-hover:opacity-100 group-hover:h-auto px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm z-10">
-                    {{{ description }}}
-                </div>
+<div id="brc-{{ id }}" class="brsw">
+    <div class="flex flex-row mb-1">
+        <div>
+            <img class="brws-actor-img w-8 h-8 rounded hover:ring-2 hover:ring-offset-1 hover:cursor-pointer" src="{{{actor.img}}}">
+        </div>
+        <div class="flex-grow text-center align-middle text-lg relative overflow-clip hover:overflow-visible">
+            <span class="group">
+                {{header.title}}<i class="brsw-repeat-card fas fa-redo hover:ring-2 hover:ring-offset-1 hover:cursor-pointer"></i>
+                {{# if description}}
+                    <div id="tooltip-description" role="tooltip"
+                        class="w-56 opacity-0 h-0 absolute transition-opacity group-hover:visible group-hover:delay-500 group-hover:duration-500 group-hover:opacity-100 group-hover:h-auto px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm z-10">
+                        {{{ description }}}
+                    </div>
+                {{/if}}
+            </span>
+        </div>
+        <div>
+            {{# if header.img }}
+                <img class="brsw-header-img w-8 h-8 rounded hover:ring-2 hover:ring-offset-1 hover:cursor-pointer" src="{{{header.img}}}"
+                    alt="Item image">
             {{/if}}
-        </span>
-    </div>
-    <div>
-        {{# if header.img }}
-            <img class="brsw-header-img w-8 h-8 rounded hover:ring-2 hover:ring-offset-1 hover:cursor-pointer" src="{{{header.img}}}"
-                alt="Item image">
-        {{/if}}
+        </div>
     </div>
 </div>
 {{# if warning }}

--- a/betterrolls-swade2/templates/damage_card.html
+++ b/betterrolls-swade2/templates/damage_card.html
@@ -1,11 +1,13 @@
 {{>"modules/betterrolls-swade2/templates/common_card_header.html"}}
 <hr>
-<div class="flex justify-between">
-    <div>{{{ text }}}</div>
-    <button class="brsw-form brsw-row-button brsw-undo-damage inline mt-2 py-0.5 px-0.5 focus:outline-none bg-white rounded-lg border border-solid focus:ring-4 focus:ring-gray-700 text-gray-800 border-gray-600 hover:text-white hover:bg-gray-700"
-            title="{{ localize "BRSW.UndoDamage" }}">
-        <i class="fas fa-undo"></i>
-    </button>
+<div class="brsw">
+    <div class="flex justify-between">
+        <div>{{{ text }}}</div>        
+        <button class="brsw-form brsw-row-button brsw-undo-damage inline mt-2 py-0.5 px-0.5 focus:outline-none bg-white rounded-lg border border-solid focus:ring-4 focus:ring-gray-700 text-gray-800 border-gray-600 hover:text-white hover:bg-gray-700"
+                title="{{ localize "BRSW.UndoDamage" }}">
+            <i class="fas fa-undo"></i>
+        </button>
+    </div>
 </div>
 {{# if trait_roll.rolls }}
     {{>"modules/betterrolls-swade2/templates/trait_roll_partial.html"}}

--- a/betterrolls-swade2/templates/item_card.html
+++ b/betterrolls-swade2/templates/item_card.html
@@ -1,36 +1,38 @@
 {{>"modules/betterrolls-swade2/templates/common_card_header.html"}}
 {{# if notes}}<div class="w-full text-center font-bold">{{{ notes }}}</div>{{/if}}
 {{# if skill }}
-    <div class="relative flex justify-between">
-        <span class="group">
-            <span class="text-lg">
-                {{ skill_title }}
-            </span>
-            {{# if skill.system.description }}
-                <div class="w-52 opacity-0 collapse h-0 absolute group-hover:visible group-hover:opacity-100 group-hover:h-auto transition-opacity group-hover:delay-500 group-hover:duration-500 px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm"
-                     role="tooltip">
-                    {{{ skill.system.description }}}
-                </div>
-            {{/if}}
-        </span>
-        {{# if ammo }}
-            <span>
-                <span class="brws-common-modifiers brsw-form flex">
-                    <img src="modules/betterrolls-swade2/assets/bullet.svg" alt="ammo" title="{{ localize 'BRSW.SubtractAmmo' }}"
-                         class="w-6 brsw-ammo-toggle cursor-pointer border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 {{#if subtract_selected}}bg-red-700{{ else }}bg-gray-500{{/if}} hover:bg-gray-900">
-                    <img src="modules/betterrolls-swade2/assets/cycle.svg" alt="reload"
-                         title="{{ localize 'BRSW.ManualAmmo' }}" class="w-6 brsw-ammo-manual cursor-pointer bg-transparent border border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 hover:invert">
+    <div class="brsw">
+        <div class="relative flex justify-between">
+            <span class="group">
+                <span class="text-lg">
+                    {{ skill_title }}
                 </span>
+                {{# if skill.system.description }}
+                    <div class="w-52 opacity-0 collapse h-0 absolute group-hover:visible group-hover:opacity-100 group-hover:h-auto transition-opacity group-hover:delay-500 group-hover:duration-500 px-3 py-2 text-sm font-medium text-white bg-gray-900 rounded-lg shadow-sm"
+                        role="tooltip">
+                        {{{ skill.system.description }}}
+                    </div>
+                {{/if}}
             </span>
-        {{/if}}
-        {{# if powerpoints}}
-            <span class="brws-common-modifiers brsw-form flex">
-                <img src="modules/betterrolls-swade2/assets/electric.svg" alt="power point" title="{{ localize 'BRSW.SubtractPP' }}"
-                     class="w-6 brsw-pp-toggle cursor-pointer border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 {{#if subtract_pp}}bg-red-700{{ else }}bg-gray-500{{/if}} hover:bg-gray-900">
-                <img src="modules/betterrolls-swade2/assets/magic-swirl.svg" alt="reload"
-                     title="{{ localize 'BRSW.ManualPP' }}" class="w-6 brsw-pp-manual cursor-pointer bg-transparent border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 hover:invert">
-            </span>
-        {{/if}}
+            {{# if ammo }}
+                <span>
+                    <span class="brws-common-modifiers brsw-form flex">
+                        <img src="modules/betterrolls-swade2/assets/bullet.svg" alt="ammo" title="{{ localize 'BRSW.SubtractAmmo' }}"
+                            class="w-6 brsw-ammo-toggle cursor-pointer border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 {{#if subtract_selected}}bg-red-700{{ else }}bg-gray-500{{/if}} hover:bg-gray-900">
+                        <img src="modules/betterrolls-swade2/assets/cycle.svg" alt="reload"
+                            title="{{ localize 'BRSW.ManualAmmo' }}" class="w-6 brsw-ammo-manual cursor-pointer bg-transparent border border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 hover:invert">
+                    </span>
+                </span>
+            {{/if}}
+            {{# if powerpoints}}
+                <span class="brws-common-modifiers brsw-form flex">
+                    <img src="modules/betterrolls-swade2/assets/electric.svg" alt="power point" title="{{ localize 'BRSW.SubtractPP' }}"
+                        class="w-6 brsw-pp-toggle cursor-pointer border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 {{#if subtract_pp}}bg-red-700{{ else }}bg-gray-500{{/if}} hover:bg-gray-900">
+                    <img src="modules/betterrolls-swade2/assets/magic-swirl.svg" alt="reload"
+                        title="{{ localize 'BRSW.ManualPP' }}" class="w-6 brsw-pp-manual cursor-pointer bg-transparent border border-solid border-slate-400 m-1 rounded hover:ring-2 hover:ring-offset-1 hover:invert">
+                </span>
+            {{/if}}
+        </div>
     </div>
     {{>"modules/betterrolls-swade2/templates/actions_partial.html"}}
     <div class="brsw-button-row">

--- a/betterrolls-swade2/templates/trait_roll_partial.html
+++ b/betterrolls-swade2/templates/trait_roll_partial.html
@@ -10,7 +10,7 @@
         {{/each}}
     </div>
 {{/if}}
-<div class="my-2 block p-1 bg-gray-500 border border-solid border-gray-700 rounded shadow hover:ring-2 hover:ring-offset-1 hover:cursor-pointer leading-6 brsw-collapse-button" data-collapse="brsw-roll-detail">
+<div class="brsw my-2 block p-1 bg-gray-500 border border-solid border-gray-700 rounded shadow hover:ring-2 hover:ring-offset-1 hover:cursor-pointer leading-6 brsw-collapse-button" data-collapse="brsw-roll-detail">
     <div class="flex justify-between align-middle">
         <span>
             {{#each trait_roll.current_roll.dice }}


### PR DESCRIPTION
As per the issue I opened, here is the fix for just .flex which fixes the issue I was seeing in Item Piles. I the action selection, trait rolls, and damage rolls and they all appear to be correct but I would suggest you have a quick look yourself before merging the PR to main.

I suck at CSS so it's entirely possible I've done something incorrectly here, but I'm fairly sure that it at least doesn't break anything.