### PR TITLE
Added support for Deflection when (melee) and (ranged) are not used

### DIFF
--- a/betterrolls-swade2/scripts/actions/target-actions.js
+++ b/betterrolls-swade2/scripts/actions/target-actions.js
@@ -183,6 +183,45 @@ export const TARGET_ACTIONS = [
     defaultChecked: "on",
     group: "BRSW.Target",
   },
+  {
+    id: "TARGET-HAS-DEFLECTION-BOTH",
+    name: "TargetHasDeflectionBoth",
+    button_name: "has Deflection (both)",
+    skillMod: -2,
+    and_selector: [
+      {
+        selector_type: "target_has_effect",
+        selector_value: "Deflection (both)"
+      },
+      {
+        selector_type: "item_type",
+        selector_value: "weapon"
+      },
+      {
+        or_selector: [
+          {
+            selector_type: "skill",
+            selector_value: "BRSW.SkillName-Athletics"
+          },
+          {
+            selector_type: "skill",
+            selector_value: "BRSW.SkillName-Shooting"
+          },
+          {
+            selector_type: "skill",
+            selector_value: "Fighting"
+          },
+          // TODO ... How to handle ranged attacks when the attacker does NOT have "Shooting" or "Athletics", so uses "Unskilled Attempt"
+          // {
+          //   selector_type: "skill",
+          //   selector_value: "BRSW.SkillName-UnskilledAttempt"
+          // },
+        ],
+      },
+    ],
+    defaultChecked: "on",
+    group: "BRSW.Target",
+  },
 
   // INVISIBILITY POWER ... Any action taken against him that requires sight is made at −4, or −6 with a raise.
   // NOTE ... The assumption is the target has an Active Effect named "Invisibility", which doesn't need any actual effect

--- a/betterrolls-swade2/scripts/actions/target-actions.js
+++ b/betterrolls-swade2/scripts/actions/target-actions.js
@@ -186,12 +186,28 @@ export const TARGET_ACTIONS = [
   {
     id: "TARGET-HAS-DEFLECTION-BOTH",
     name: "TargetHasDeflectionBoth",
-    button_name: "has Deflection (both)",
+    button_name: "has Deflection",
     skillMod: -2,
     and_selector: [
       {
         selector_type: "target_has_effect",
-        selector_value: "Deflection (both)"
+        selector_value: "Deflection"
+      },
+      {
+        not_selector: [
+          {
+            or_selector: [
+              {
+                selector_type: "target_has_effect",
+                selector_value: "Deflection (melee)"
+              },
+              {
+                selector_type: "target_has_effect",
+                selector_value: "Deflection (ranged)"
+              },
+            ]
+          }
+        ]
       },
       {
         selector_type: "item_type",


### PR DESCRIPTION
If you look at the commit history on the PR, I actually tried two different versions but I prefer the second. How I've set this up is that we check for any effect named "Deflection" but we exclude anything named "Deflection (melee)" or "Deflection (ranged)." This allows support for anyone who is using a Deflection effect (even if it wasn't added by SUCC/SWIM) to be able to take advantage of the Deflection functionality in BR2.

The previous version had me directly checking for "Deflection (both)" but I really didn't like that name and it also made it a requirement that everyone had to use that naming convention.