### PR TITLE
Both injury cards and shaken only damage cards no longer show a popout

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -93,7 +93,7 @@ export class BrCommonCard {
     this.update_list = {}; // List of properties pending to be updated
     this.resist_buttons = [];
     this.trait_roll = new TraitRoll();
-    this.popup_shown_to = [];
+    this.popup_shown = false;
     if (message) {
       const data = this.message.getFlag("betterrolls-swade2", "br_data");
       if (data) {
@@ -125,13 +125,13 @@ export class BrCommonCard {
   create_popout() {
     if (
       game.user.id !== this.message.user.id ||
-      this.popup_shown_to.includes(game.user.id)
+      this.popup_shown
     ) {
       return;
     }
     if (game.settings.get("betterrolls-swade2", "auto_popout_chat")) {
       new ChatPopout(this.message).render(true);
-      this.popup_shown_to.push(game.user.id);
+      this.popup_shown = true;
       this.save().catch(() => {
         console.error("Error saving card data after popup rendering");
       });
@@ -166,7 +166,7 @@ export class BrCommonCard {
       trait_roll: this.trait_roll,
       resist_buttons: this.resist_buttons,
       damage: this.damage,
-      popup_shown_to: this.popup_shown_to,
+      popup_shown: this.popup_shown,
     };
   }
 
@@ -186,7 +186,7 @@ export class BrCommonCard {
       "macro_buttons",
       "resist_buttons",
       "damage",
-      "popup_shown_to",
+      "popup_shown",
     ];
     for (let field of FIELDS) {
       this[field] = data[field];
@@ -197,6 +197,10 @@ export class BrCommonCard {
         "betterrolls-swade2",
         "render_data",
       );
+    }
+    //Backwards compatibility so that we don't show a bunch of old popouts
+    if (data.popup_shown_to?.length > 0) {
+      data.popup_shown = true;
     }
   }
 

--- a/betterrolls-swade2/scripts/damage_card.js
+++ b/betterrolls-swade2/scripts/damage_card.js
@@ -74,6 +74,10 @@ export async function create_damage_card(
     },
     "modules/betterrolls-swade2/templates/damage_card.html",
   );
+  if (wounds == 0) {
+    //If we're not dealing any wounds, don't bother popping out the card since there's no action required
+    br_message.popup_shown = true;
+  }
   br_message.update_list = { ...br_message.update_list, ...{ user: user.id } };
   br_message.type = BRSW_CONST.TYPE_DMG_CARD;
   await br_message.render();

--- a/betterrolls-swade2/scripts/incapacitation_card.js
+++ b/betterrolls-swade2/scripts/incapacitation_card.js
@@ -268,6 +268,7 @@ export async function create_injury_card(token_id, reason) {
   );
   br_message.update_list = { ...br_message.update_list, ...{ user: user.id } };
   br_message.type = BRSW_CONST.TYPE_INJ_CARD;
+  br_message.popup_shown = true; //The injury result has no action so we don't show the popout
   await br_message.render();
   await br_message.save();
   Hooks.call("BRSW-InjuryAEApplied", br_message, injury_effect, reason);


### PR DESCRIPTION
This is what I mentioned to you on Discord. I reworked the popup_shown property to just be a bool and then changed it so that injury cards and shaken only damage cards no longer pop out.