### PR TITLE
Fix bug with getting wild die preset

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -943,9 +943,7 @@ function set_wild_die_theme(wildDie) {
     foundry.utils.setProperty(wildDie, "options.appearance.system", dieSystem);
   }
   // Get the dicePreset for the given die type
-  const dicePreset = game.dice3d?.DiceFactory.systems[dieSystem].dice.find(
-    (d) => d.type === "d" + wildDie.faces,
-  );
+  const dicePreset = game.dice3d?.DiceFactory.systems.get(dieSystem).dice.get("d" + wildDie.faces);
   if (!dicePreset) {
     return;
   }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -943,7 +943,7 @@ function set_wild_die_theme(wildDie) {
     foundry.utils.setProperty(wildDie, "options.appearance.system", dieSystem);
   }
   // Get the dicePreset for the given die type
-  const dicePreset = game.dice3d?.DiceFactory.systems.get(dieSystem).dice.get("d" + wildDie.faces);
+const dicePreset = game.dice3d?.DiceFactory.systems.get(dieSystem)?.dice?.get("d" + wildDie.faces);
   if (!dicePreset) {
     return;
   }


### PR DESCRIPTION
Fixed an issue with getting dice presets. Maps do not allow [] for accessing values. You need to use .get(key) instead.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix bug with retrieving wild die presets by using the correct method to access values from a Map instead of using array-like indexing.

Bug Fixes:
- Fixed an issue with accessing dice presets by using the correct method to retrieve values from a Map.

<!-- Generated by sourcery-ai[bot]: end summary -->