### PR TITLE
Add support for skill override

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -489,13 +489,13 @@ export function get_action_from_click(event) {
  * @param old_options - Options used as default
  */
 export function get_roll_options(old_options) {
-  let modifiers = old_options.additionalMods || [];
-  let dmg_modifiers = old_options.dmgMods || [];
-  let tn = old_options.tn || 4;
-  let tn_reason = old_options.tn_reason || game.i18n.localize("BRSW.Default");
-  let rof = old_options.rof || 1;
+  let modifiers = old_options?.additionalMods || [];
+  let dmg_modifiers = old_options?.dmgMods || [];
+  let tn = old_options?.tn || 4;
+  let tn_reason = old_options?.tn_reason || game.i18n.localize("BRSW.Default");
+  let rof = old_options?.rof || 1;
   // We only check for modifiers when there are no old ones.
-  if (!old_options.hasOwnProperty("additionalMods")) {
+  if (!old_options?.hasOwnProperty("additionalMods")) {
     $(".brsw-chat-form .brws-selectable.brws-selected").each((_, element) => {
       if (element.dataset.type === "modifier") {
         modifiers.push(element.dataset.value);

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -1301,7 +1301,7 @@ export function process_common_actions(action, extra_data, macros, actor) {
     extra_data.rof = action.dice;
   }
   if (action.tnOverride) {
-    if (action.tnOverride.toLowerCase() === "parry" && game.user.targets) {
+    if (isNaN(action.tnOverride) && action.tnOverride.toLowerCase() === "parry" && game.user.targets) {
       extra_data.tn = parseInt(
         game.user.targets.first().actor.system.stats.parry.value,
       );

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -194,7 +194,7 @@ function check_selector(type, value, item, actor) {
   } else if (type === "actor_name") {
     selected = actor.name.toLowerCase().includes(value.toLowerCase());
   } else if (type === "actor_has_item") {
-    const ITEM_TYPES = ["weapon", "armor", "shield", "gear", "consumable"];
+    const ITEM_TYPES = ["skill", "weapon", "armor", "shield", "gear", "consumable"];
     const item = actor.items.find((item) => {
       return (
         ITEM_TYPES.indexOf(item.type) !== -1 &&
@@ -582,6 +582,7 @@ export class WorldGlobalActions extends FormApplication {
         "name",
         "button_name",
         "skillMod",
+        "skillOverride",
         "dmgMod",
         "apMod",
         "dmgOverride",


### PR DESCRIPTION
Allow user to set a skill to use as an override. Also, makes sure "actor_has_item" treats a skill as an item, which it is.

Current behavior: Custom global actions do not provide access to the skillOverride property. The actor_has_item selector does not include "skill" as an option.

New behavior: Custom global actions will now provide access to the skillOverride property to allow access to the functionality that item actions currently have. Also, the actor_has_item selector will now include "skill" as an option. This will allow custom global actions to determine if an actor has a skill in order to show the action.