### PR TITLE
Add actor_has_skill selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 4.5 
+* Actions: Added `actor_has_skill` selector
+* Cards: Added BRCard parameter to BRSW-CardRendered hook
+
 # Version 4.4 aka Broken by a Wild die
 * Bugfix: Better rolls is now working with current DSN (David-a-rivera)
 

--- a/betterrolls-swade2/module.json
+++ b/betterrolls-swade2/module.json
@@ -1,7 +1,7 @@
 {
   "title": "Better Rolls 2 for Savage Worlds",
   "description": "A module to make rolling in SWADE easier for experienced players.",
-  "version": "4.4",
+  "version": "4.5",
   "languages": [
     {
       "lang": "en",

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -195,7 +195,7 @@ Hooks.on("renderChatMessage", (message, html) => {
         chat_bar[0].scrollTop = chat_bar[0].scrollHeight;
       }
     }
-    Hooks.call("BRSW-CardRendered");
+    Hooks.call("BRSW-CardRendered", card);
   }
 });
 

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -193,6 +193,11 @@ function check_selector(type, value, item, actor) {
     selected = item.type === value;
   } else if (type === "actor_name") {
     selected = actor.name.toLowerCase().includes(value.toLowerCase());
+  } else if (type === "actor_has_skill") {
+    actor.items.find((item) => {
+      return item.type === 'skill'&&
+        item.name.toLowerCase() === game.i18n.localize(value).toLowerCase()
+    });
   } else if (type === "actor_has_item") {
     const ITEM_TYPES = ["weapon", "armor", "shield", "gear", "consumable"];
     const item = actor.items.find((item) => {

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -194,10 +194,11 @@ function check_selector(type, value, item, actor) {
   } else if (type === "actor_name") {
     selected = actor.name.toLowerCase().includes(value.toLowerCase());
   } else if (type === "actor_has_skill") {
-    actor.items.find((item) => {
-      return item.type === 'skill'&&
+    const item = actor.items.find((item) => {
+      return item.type === 'skill' &&
         item.name.toLowerCase() === game.i18n.localize(value).toLowerCase()
     });
+    return !!item;
   } else if (type === "actor_has_item") {
     const ITEM_TYPES = ["weapon", "armor", "shield", "gear", "consumable"];
     const item = actor.items.find((item) => {

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -122,6 +122,7 @@ a `selector_value` for a simple selection. You can also use `and_selector` and g
   like `system.advances.value`) and value a value (like 4). This coerces the values using javascript `==`.
 * `item_value`: The same selector as above but for items instead of actors.
 * `item_has_damage`: This will show the action if the item has a damage value. The value is ignored.
+* `actor_has_skill`: This will show the action if the actor has a skill with the same name as the value.
 * `actor_has_item`: This will show the action if the actor has an item with the same name as the value.
 * `actor_equips_item`: This action will appear when the actor has an item (see above) with the same name as the value
   equipped, not just owned.

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -122,7 +122,7 @@ a `selector_value` for a simple selection. You can also use `and_selector` and g
   like `system.advances.value`) and value a value (like 4). This coerces the values using javascript `==`.
 * `item_value`: The same selector as above but for items instead of actors.
 * `item_has_damage`: This will show the action if the item has a damage value. The value is ignored.
-* `actor_has_skill`: This will show the action if the actor has a skill with the same name as the value.
+* `actor_has_skill`: This will show the action if the actor has a skill with the same name as the value. For example, `actor_has_skill: "Acrobatics"` would show the action if the actor has a skill named "Acrobatics".
 * `actor_has_item`: This will show the action if the actor has an item with the same name as the value.
 * `actor_equips_item`: This action will appear when the actor has an item (see above) with the same name as the value
   equipped, not just owned.


### PR DESCRIPTION
Added new selector: actor_has_skill. This will allow for only showing an action if the value matches a skill name the actor has.

Also added a parameter for the BRSW-CardRendered hook. The parameter is the BRCard. This will allow downstream modules to react to a change to a BR Card. My Personal use case is to track the rolls of my players so that I can generate a summary of the rolls to easily track who succeeded and who failed withou having to wade through the chat clutter.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add the `actor_has_skill` selector to allow actions to be shown based on an actor's skills and enhance the BRSW-CardRendered hook with a BRCard parameter for better module interaction.

New Features:
- Introduce the `actor_has_skill` selector to conditionally display actions based on an actor's skills.

Enhancements:
- Add a BRCard parameter to the BRSW-CardRendered hook to enable downstream modules to react to changes in BR Cards.

Documentation:
- Update documentation to include the new `actor_has_skill` selector in the Global Actions guide.

<!-- Generated by sourcery-ai[bot]: end summary -->