### PR TITLE
Add setting for custom No Actions Selected message

### DIFF
--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -501,6 +501,8 @@
   "BRSW.PopoutChatButton": "Add a button to the cards to popout",
   "BRSW.PopoutChatButtonHint": "Add another button to the head of the cards allowing you to popout easier",
   "BRSW.PopoutCard": "Popout this card",
+  "BRSW.No_Action_Message": "No actions selected message",
+  "BRSW.No_Action_Message_Hint": "Set the message to show the player's when no action was selected",
   "BRSW.NoActionsSelected": "No actions selected",
   "BRSW.ShowPPShotsSetting": "Show shots or powerpoints in the card",
   "BRSW.ShowPPShotsSettingHint": "This adds visible info in the card about the situation of the powers or shots when the card is displayed",

--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -502,7 +502,7 @@
   "BRSW.PopoutChatButtonHint": "Add another button to the head of the cards allowing you to popout easier",
   "BRSW.PopoutCard": "Popout this card",
   "BRSW.No_Action_Message": "No actions selected message",
-  "BRSW.No_Action_Message_Hint": "Set the message to show the player's when no action was selected",
+  "BRSW.No_Action_Message_Hint": "Set the message to show the players when no action was selected",
   "BRSW.NoActionsSelected": "No actions selected",
   "BRSW.ShowPPShotsSetting": "Show shots or powerpoints in the card",
   "BRSW.ShowPPShotsSettingHint": "This adds visible info in the card about the situation of the powers or shots when the card is displayed",

--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -502,7 +502,7 @@
   "BRSW.PopoutChatButtonHint": "Add another button to the head of the cards allowing you to popout easier",
   "BRSW.PopoutCard": "Popout this card",
   "BRSW.No_Action_Message": "No actions selected message",
-  "BRSW.No_Action_Message_Hint": "Set the message to show the players when no action was selected",
+  "BRSW.No_Action_MessageHint": "Set the message to show the players when no action was selected",
   "BRSW.NoActionsSelected": "No actions selected",
   "BRSW.ShowPPShotsSetting": "Show shots or powerpoints in the card",
   "BRSW.ShowPPShotsSettingHint": "This adds visible info in the card about the situation of the powers or shots when the card is displayed",

--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -617,6 +617,7 @@ export class BrCommonCard {
     data.bennie_avaliable = this.bennie_avaliable;
     data.show_rerolls = this.show_rerolls;
     data.selected_actions = this.get_selected_actions();
+    data.no_actions_message = SettingsUtils.getWorldSetting("no-action-message");
     data.has_feet_buttons = this.has_feet_buttons;
     data.skill_tooltip = this.skill_tooltip;
     data.show_popup_button = SettingsUtils.getUserSetting("popout_chat_button");

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -393,6 +393,12 @@ function register_world_settings() {
     type: String,
     choices: br_choices,
   });
+  SettingsUtils.registerBR2WorldSetting("no-action-message", {
+    name: game.i18n.localize("BRSW.No_Action_Message"),
+    hint: game.i18n.localize("BRSW.No_Action_Message_Hint"),
+    default: game.i18n.localize("BRSW.NoActionsSelected"),
+    type: String
+  });
   SettingsUtils.registerBR2WorldSetting("result-card", {
     name: game.i18n.localize("BRSW.See_result_card"),
     hint: game.i18n.localize("BRSW.See_result_hint"),

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -395,7 +395,7 @@ function register_world_settings() {
   });
   SettingsUtils.registerBR2WorldSetting("no-action-message", {
     name: game.i18n.localize("BRSW.No_Action_Message"),
-    hint: game.i18n.localize("BRSW.No_Action_Message_Hint"),
+    hint: game.i18n.localize("BRSW.No_Action_MessageHint"),
     default: game.i18n.localize("BRSW.NoActionsSelected"),
     type: String
   });

--- a/betterrolls-swade2/scripts/settings_config.js
+++ b/betterrolls-swade2/scripts/settings_config.js
@@ -64,7 +64,11 @@ export class SettingsConfig extends FormApplication {
     s.id = s.key;
     s.name = game.i18n.localize(s.name);
     s.hint = game.i18n.localize(s.hint);
-    s.value = s.value !== undefined ? s.value : game.i18n.localize(s.default);
+    s.value = s.value !== undefined ? s.value : 
+        (typeof s.default === 'string' && s.default.startsWith('BRSW.') ? 
+            game.i18n.localize(s.default) : 
+            s.default
+        );
     s.type = setting.type instanceof Function ? setting.type.name : "String";
     s.isCheckbox = setting.type === Boolean;
     s.isSelect = s.choices !== undefined;

--- a/betterrolls-swade2/scripts/settings_config.js
+++ b/betterrolls-swade2/scripts/settings_config.js
@@ -64,7 +64,7 @@ export class SettingsConfig extends FormApplication {
     s.id = s.key;
     s.name = game.i18n.localize(s.name);
     s.hint = game.i18n.localize(s.hint);
-    s.value = s.value !== undefined ? s.value : 
+    s.value = s.value ?? 
         (typeof s.default === 'string' && s.default.startsWith('BRSW.') ? 
             game.i18n.localize(s.default) : 
             s.default

--- a/betterrolls-swade2/scripts/settings_config.js
+++ b/betterrolls-swade2/scripts/settings_config.js
@@ -64,7 +64,7 @@ export class SettingsConfig extends FormApplication {
     s.id = s.key;
     s.name = game.i18n.localize(s.name);
     s.hint = game.i18n.localize(s.hint);
-    s.value = s.value !== undefined ? s.value : s.default;
+    s.value = s.value !== undefined ? s.value : game.i18n.localize(s.default);
     s.type = setting.type instanceof Function ? setting.type.name : "String";
     s.isCheckbox = setting.type === Boolean;
     s.isSelect = s.choices !== undefined;

--- a/betterrolls-swade2/templates/actions_partial.html
+++ b/betterrolls-swade2/templates/actions_partial.html
@@ -9,7 +9,7 @@
                 </span>
             {{/each}}
         {{else}}
-            {{ localize "BRSW.NoActionsSelected" }}
+            {{ this.no_actions_message }}
         {{/if}}
     </div>
 {{/if}}

--- a/betterrolls-swade2/templates/actions_partial.html
+++ b/betterrolls-swade2/templates/actions_partial.html
@@ -9,7 +9,7 @@
                 </span>
             {{/each}}
         {{else}}
-            {{ this.no_actions_message }}
+            {{ localize this.no_actions_message }}
         {{/if}}
     </div>
 {{/if}}


### PR DESCRIPTION
Added a setting to allow users to choose their own "No actions selected" message.

Reason: While code uses the term "action" for what equate to modifiers, this terminology confuses some players. The setting will allow GMs to keep things the same, or create a message catered to their players. For example: "Click here to add modifiers" or "Add modifiers by clicking here" or "For all those juicy modifiers, click in the gray box", etc.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new setting that allows users to customize the 'No actions selected' message, enhancing user experience by providing flexibility in message display. Update the settings configuration to ensure localization of default values.

New Features:
- Introduce a customizable setting for the 'No actions selected' message, allowing users to define their own message text.

Enhancements:
- Update the settings configuration to localize default values for settings, ensuring consistent language support.

<!-- Generated by sourcery-ai[bot]: end summary -->