### PR TITLE
The save macro button now only appears for owners and trusted players

### DIFF
--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -174,12 +174,16 @@ Hooks.on("renderChatMessage", (message, html) => {
       activate_remove_status_card_listeners(card, html, card.type);
     }
     // Hide forms to non-master, non owner
-    if (game.user.id !== message.user.id && !game.user.isGM) {
+    if (!message.isOwner) {
       html.find(".brsw-form").addClass("brsw-collapsed");
     }
     // Hide master only sections
     if (!game.user.isGM) {
       html.find(".brsw-master-only").remove();
+    }    
+    // Hide save macro button from non-owner, non-trusted players
+    if (!message.isOwner && !game.user.isTrusted) {
+      html.find(".brsw-owner-trusted-only").remove();
     }
     if (Object.keys(message.apps).length < 1) {
       // Don't create popout when rendering popouts.

--- a/betterrolls-swade2/templates/common_card_header.html
+++ b/betterrolls-swade2/templates/common_card_header.html
@@ -16,7 +16,7 @@
         <span class="twbr-group">
             {{header.title}}<i class="brsw-repeat-card fas fa-redo hover:twbr-ring-2
             hover:twbr-ring-offset-1 hover:twbr-cursor-pointer"></i>
-            {{#unless vehicle_actor}}<i class="brsw-save-macro fa fa-save hover:twbr-ring-2
+            {{#unless vehicle_actor}}<i class="brsw-owner-trusted-only brsw-save-macro fa fa-save hover:twbr-ring-2
             hover:twbr-ring-offset-1 hover:twbr-cursor-pointer"></i>{{/unless}}
             {{# if description}}
                 <div id="tooltip-description" role="tooltip"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Restrict the save macro button visibility to owners and trusted players, enhancing the security and user interface by ensuring that only authorized users can access certain features.

Enhancements:
- Restrict the visibility of the save macro button to only owners and trusted players in the chat message rendering logic.

<!-- Generated by sourcery-ai[bot]: end summary -->