### PR TITLE
Added a button to the damage card to mark wildcards as defeated

### DIFF
--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -183,6 +183,7 @@
   "BRSW.ManualAmmo": "Reload",
   "BRSW.ManuallyAdded": "Manually added",
   "BRSW.ManualPP": "Manual PP management",
+  "BRSW.MarkDefeated": "Mark Defeated",
   "BRSW.Master_only_result_card": "Only the card owner can see the card",
   "BRSW.MasterAndGM": "Card owner and GM",
   "BRSW.MasterModifiers": "Master mods.",

--- a/betterrolls-swade2/scripts/damage_card.js
+++ b/betterrolls-swade2/scripts/damage_card.js
@@ -258,6 +258,11 @@ export function activate_damage_card_listeners(message, html) {
       console.error("Error creating incapacitation card");
     });
   });
+  html.find(".brsw-mark-defeated").click(async () => {
+    await game.succ.removeCondition("incapacitated", br_card.token);
+    await game.succ.removeCondition("bleeding-out", br_card.token);
+    await game.succ.addCondition("dead", br_card.token);
+  });
   html.find(".brsw-injury-button").click(() => {
     // noinspection JSIgnoredPromiseFromCall
     create_injury_card(br_card.token_id, "gritty");

--- a/betterrolls-swade2/templates/damage_card.html
+++ b/betterrolls-swade2/templates/damage_card.html
@@ -36,6 +36,15 @@
             {{ localize "BRSW.IncapacitationCard" }}
         </button>
     </div>
+    <hr>
+    <div class="brsw-button-row brsw-form">
+        <button class="brsw-mark-defeated twbr-py-0.5 twbr-px-5 focus:twbr-outline-none
+                twbr-bg-white twbr-rounded-lg twbr-border twbr-border-solid focus:twbr-ring-4
+                focus:twbr-ring-gray-700 twbr-text-gray-800 twbr-border-gray-600
+                hover:twbr-text-white hover:twbr-bg-gray-700">
+            {{ localize "BRSW.MarkDefeated" }}
+        </button>
+    </div>
 {{/if}}
 {{# if show_injury }}
     <hr>


### PR DESCRIPTION
I found myself wanting this button constantly and so I finally decided to add it. This gives a way to bypass the normal incap flow on NPC wildcards when you just want to skip to them being dead.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce a new button on the damage card to mark NPC wildcards as defeated, streamlining the process of handling their status changes in the game.

New Features:
- Add a button to the damage card interface that allows users to mark NPC wildcards as defeated, bypassing the normal incapacitation flow.

<!-- Generated by sourcery-ai[bot]: end summary -->