### PR TITLE
Fixed deprecation warning

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -697,7 +697,6 @@ export class BrCommonCard {
         token: this.token?.id,
         alias: this.actor.name,
       },
-      type: CONST.CHAT_MESSAGE_TYPES.ROLL,
       blind: whisper_data.blind,
       flags: { core: { canPopout: true } },
     };


### PR DESCRIPTION
Apparently just removing this line completely was all that was needed. I did a few different tests with it and it appeared fine to me.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix deprecation warning by removing the deprecated 'type' property from chat message data in BrCommonCard.js.

Bug Fixes:
- Remove deprecated 'type' property from chat message data to fix deprecation warning.

<!-- Generated by sourcery-ai[bot]: end summary -->