### PR TITLE
Fixed the settings menu not opening

### DIFF
--- a/betterrolls-swade2/scripts/settings_config.js
+++ b/betterrolls-swade2/scripts/settings_config.js
@@ -64,7 +64,7 @@ export class SettingsConfig extends FormApplication {
     s.id = s.key;
     s.name = game.i18n.localize(s.name);
     s.hint = game.i18n.localize(s.hint);
-    s.value = s.value !== undefined ? s.value : game.i18n.localize(s.default);
+    s.value = s.value ?? s.default;
     s.type = setting.type instanceof Function ? setting.type.name : "String";
     s.isCheckbox = setting.type === Boolean;
     s.isSelect = s.choices !== undefined;


### PR DESCRIPTION
I guess the guy who made this change just took my review suggestion and didn't bother to test it. The default value is not always a string and so it throws an error when it tries to localize a bool.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the issue with the settings menu not opening by ensuring that default values are correctly assigned without attempting to localize non-string types.

Bug Fixes:
- Fix the settings menu not opening by correctly handling default values that are not strings.

<!-- Generated by sourcery-ai[bot]: end summary -->