### PR TITLE
Changed the way we create a preview template so that we can't create duplicates

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -359,9 +359,8 @@ function preview_template(ev, br_card) {
     { parent: canvas.scene },
   );
   // noinspection JSPotentiallyInvalidConstructorUsage
-  let template = new CONFIG.MeasuredTemplate.objectClass(template_base);
-  Hooks.call("BRSW-BeforePreviewingTemplate", template, br_card, ev);
-  template.drawPreview(ev);
+  CONFIG.MeasuredTemplate.objectClass.fromPreset(type);
+  Hooks.call("BRSW-BeforePreviewingTemplate", CONFIG.SWADE.activeMeasuredTemplatePreview, br_card, ev);
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent the accidental creation of duplicate preview templates.