### PR TITLE
Pass through the item when creating the template

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -355,7 +355,7 @@ function preview_template(ev, br_card) {
   if (canvas.grid.distance % 5 === 0) {
     templateData.distance *= 5;
   }
-  CONFIG.MeasuredTemplate.objectClass.fromPreset(type);
+  CONFIG.MeasuredTemplate.objectClass.fromPreset(type, br_card.item);
   Hooks.call(
     "BRSW-BeforePreviewingTemplate",
     CONFIG.SWADE.activeMeasuredTemplatePreview,


### PR DESCRIPTION
This brings the logic in line with how it works in swade. I need this in order to add swade support to the Region Attacher module.

## Summary by Sourcery

Pass the item to the MeasuredTemplate.objectClass.fromPreset function.