### PR TITLE
Fixed up the values we're using in the chat data

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -733,12 +733,16 @@ export class BrCommonCard {
    */
   create_basic_chat_data() {
     const whisper_data = getWhisperData();
+    //Get the actual token if we have one.
+    //This is different than this.token since that will fallback to grabbing the first token for the base actor rather than this specific actor
+    let token = canvas.tokens.get(this.actor.token?.id);
     const chatData = {
-      user: this.actor._idx,
+      user: game.user.id,
       content: "<p>Default content, likely an error in Better Rolls</p>",
       speaker: {
-        actor: this.actor._idx,
-        token: this.token?.id,
+        actor: this.actor._id,
+        scene: token?.scene.id,
+        token: token?.id,
         alias: this.actor.name,
       },
       blind: whisper_data.blind,


### PR DESCRIPTION
I'm working on a module that interacts with the chat card speaker data and what we were send from BR was wrong in a couple ways. Let me know if you want me to go into more detail but the TLDR is that we now use the correct user, actor, and token based on the context of where we're triggering the roll.

## Summary by Sourcery

Use the correct user, actor, and token based on the context of where the roll is triggered.

Bug Fixes:
- Use the correct actor ID instead of the index.
- Use the correct token ID by retrieving the actual token from the canvas.