### PR TITLE
Added support for aiming actions that can ignore relevant penalties

### DIFF
--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -11,6 +11,7 @@
   "BRSW.AddD6Damage": "Add a d6 to damage",
   "BRSW.AddDamage": "Add fixed damage",
   "BRSW.AddModifier": "Add modifier",
+  "BRSW.Aiming": "Aiming",
   "BRSW.AllSoaked": "<p>but soaked all wounds, removing shaken</p>",
   "BRSW.Alt_click_action": "Alt click action",
   "BRSW.Alt_click_hint": "Select what happens when you click a name while pressing Alt (World)",

--- a/betterrolls-swade2/scripts/actions/builtin-actions.js
+++ b/betterrolls-swade2/scripts/actions/builtin-actions.js
@@ -60,7 +60,8 @@ export const SYSTEM_GLOBAL_ACTION = [
     id: "MARKSMAN",
     name: "BRSW.EdgeName-Marksman",
     button_name: "BRSW.EdgeName-Marksman",
-    skillMod: "+1",
+    skillMod: 1,
+    aimingIgnoreMod: 2,
     and_selector: [
       {
         selector_type: "actor_has_edge",

--- a/betterrolls-swade2/scripts/actions/combat_options.js
+++ b/betterrolls-swade2/scripts/actions/combat_options.js
@@ -2,6 +2,20 @@
 
 export const COMBAT_OPTIONS = [
   {
+    id: "AIM",
+    name: "BRSW.Aiming",
+    button_name: "BRSW.Aiming",
+    skillMod: 2,
+    aimingIgnoreMod: 4,
+    selector_type: "skill",
+    selector_value: "BRSW.Shooting",
+    group: "BRSW.AttackOption",
+    defaultChecked: {
+      selector_type: "actor_has_effect",
+      selector_value: "BRSW.Aiming",
+    },
+  },
+  {
     id: "WTK",
     name: "BRSW.WildAttack",
     button_name: "BRSW.WildAttack",
@@ -34,6 +48,7 @@ export const COMBAT_OPTIONS = [
     change_location: "arms",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "CS-HEAD",
@@ -47,6 +62,7 @@ export const COMBAT_OPTIONS = [
     change_location: "head",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "CS-LEG",
@@ -58,6 +74,7 @@ export const COMBAT_OPTIONS = [
     change_location: "legs",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "1-LightCover",
@@ -76,6 +93,7 @@ export const COMBAT_OPTIONS = [
     ],
     group: "BRSW.Cover",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "2-MediumCover",
@@ -94,6 +112,7 @@ export const COMBAT_OPTIONS = [
     ],
     group: "BRSW.Cover",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "3-HeavyCover",
@@ -112,6 +131,7 @@ export const COMBAT_OPTIONS = [
     ],
     group: "BRSW.Cover",
     group_single: true,
+    aiming_ignores: true,
   },
   {
     id: "4-NearTotalCover",
@@ -130,6 +150,7 @@ export const COMBAT_OPTIONS = [
     ],
     group: "BRSW.Cover",
     group_single: true,
+    aiming_ignores: true,
   },
 
   {

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -763,6 +763,7 @@ async function get_new_roll_options(
         objetive,
         origin_token,
         br_card.item,
+        extra_data,
       );
       br_card.trait_roll.tn = target_data.value;
       br_card.trait_roll.tn_reason = target_data.reason;
@@ -999,6 +1000,22 @@ export async function roll_trait(br_card, trait_dice, dice_label, extra_data) {
     br_card.trait_roll.wild_die = true;
   } else {
     br_card.trait_roll.wild_die = false;
+  }
+  if (extra_data.total_aiming_ignorable_penalties > 0 && extra_data.aiming_ignore_data.length > 0) {
+    //We are aiming and we have penalties that we can ignore
+    //Loop over our aiming modifiers and adjust them to reflect the ignored penalties
+    extra_data.aiming_ignore_data = extra_data.aiming_ignore_data.sort((a, b) => a.ignore_mod - b.ignore_mod);
+    for (let ignore_data of extra_data.aiming_ignore_data) {
+      if (ignore_data.modifier.value >= extra_data.total_aiming_ignorable_penalties) {
+        //The default skill mod is more than we would ignore so just use that
+        continue;
+      }
+      ignore_data.modifier.value = Math.min(extra_data.total_aiming_ignorable_penalties, ignore_data.ignore_mod);
+      extra_data.total_aiming_ignorable_penalties -= ignore_data.modifier.value;
+      if (extra_data.total_aiming_ignorable_penalties == 0) {
+        break;
+      }
+    }
   }
   br_card.trait_roll.modifiers = roll_options.modifiers;
   if (extra_data.tn) {
@@ -1277,6 +1294,16 @@ export function process_common_actions(action, extra_data, macros, actor) {
     } else {
       extra_data.modifiers = [modifier];
     }
+    if (action.aimingIgnoreMod > 0) {
+      //This is an aiming type action which can ignore certain penalties
+      //Save some data about it so we can process it later
+      add_aiming_ignore_modifier(extra_data, modifier, action.aimingIgnoreMod);
+    } else if (action.aiming_ignores) {
+      //This is an action that can be ignored by aiming
+      //Save some data about it so we can process it later
+      extra_data.total_aiming_ignorable_penalties = extra_data.total_aiming_ignorable_penalties ?? 0;
+      extra_data.total_aiming_ignorable_penalties += Math.abs(modifier.value);
+    }
   }
   if (action.rerollSkillMod) {
     //Reroll
@@ -1383,4 +1410,21 @@ export function process_minimum_str_modifiers(item, actor, name) {
     );
   }
   return new_mod;
+}
+
+/**
+ * Added a penalty that can be ignored by aiming to the extra_data
+ * @param extra_data
+ * @param modifier
+ */
+export function add_aiming_ignore_modifier(extra_data, modifier, ignore_mod) {
+  let aiming_ignore_data = {
+    modifier: modifier,
+    ignore_mod: ignore_mod
+  };
+  if (extra_data.aiming_ignore_data) {
+    extra_data.aiming_ignore_data.push(aiming_ignore_data);
+  } else {
+    extra_data.aiming_ignore_data = [aiming_ignore_data];
+  }
 }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -1003,19 +1003,7 @@ export async function roll_trait(br_card, trait_dice, dice_label, extra_data) {
   }
   if (extra_data.total_aiming_ignorable_penalties > 0 && extra_data.aiming_ignore_data.length > 0) {
     //We are aiming and we have penalties that we can ignore
-    //Loop over our aiming modifiers and adjust them to reflect the ignored penalties
-    extra_data.aiming_ignore_data = extra_data.aiming_ignore_data.sort((a, b) => a.ignore_mod - b.ignore_mod);
-    for (let ignore_data of extra_data.aiming_ignore_data) {
-      if (ignore_data.modifier.value >= extra_data.total_aiming_ignorable_penalties) {
-        //The default skill mod is more than we would ignore so just use that
-        continue;
-      }
-      ignore_data.modifier.value = Math.min(extra_data.total_aiming_ignorable_penalties, ignore_data.ignore_mod);
-      extra_data.total_aiming_ignorable_penalties -= ignore_data.modifier.value;
-      if (extra_data.total_aiming_ignorable_penalties == 0) {
-        break;
-      }
-    }
+    apply_aiming_ignore(extra_data);
   }
   br_card.trait_roll.modifiers = roll_options.modifiers;
   if (extra_data.tn) {
@@ -1426,5 +1414,26 @@ export function add_aiming_ignore_modifier(extra_data, modifier, ignore_mod) {
     extra_data.aiming_ignore_data.push(aiming_ignore_data);
   } else {
     extra_data.aiming_ignore_data = [aiming_ignore_data];
+  }
+}
+
+/**
+ * Adjust our action modifiers to reflect ignored penalties
+ * @param extra_data
+ */
+function apply_aiming_ignore(extra_data) {
+  //Sort the list so that the smaller mods are used first. This ensures we maximize the benefit
+  extra_data.aiming_ignore_data = extra_data.aiming_ignore_data.sort((a, b) => a.ignore_mod - b.ignore_mod);
+  //Loop over our aiming modifiers and adjust them to reflect the ignored penalties
+  for (let ignore_data of extra_data.aiming_ignore_data) {
+    if (ignore_data.modifier.value >= extra_data.total_aiming_ignorable_penalties) {
+      //The default skill mod is more than we would ignore so just use that
+      continue;
+    }
+    ignore_data.modifier.value = Math.min(extra_data.total_aiming_ignorable_penalties, ignore_data.ignore_mod);
+    extra_data.total_aiming_ignorable_penalties -= ignore_data.modifier.value;
+    if (extra_data.total_aiming_ignorable_penalties == 0) {
+      break;
+    }
   }
 }

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -264,6 +264,7 @@ function calculate_generic_distance_modifier(
   target_token,
   skill,
   tn,
+  extra_data,
 ) {
   const range = item.system.range.split("/");
   if (origin_token.document.elevation !== target_token.document.elevation) {
@@ -311,6 +312,9 @@ function calculate_generic_distance_modifier(
         -distance_penalty,
       ),
     );
+    //Range penalties can be ignored by aiming so add it to the total
+    extra_data.total_aiming_ignorable_penalties = extra_data.total_aiming_ignorable_penalties ?? 0;
+    extra_data.total_aiming_ignorable_penalties += distance_penalty;
   }
 }
 
@@ -329,6 +333,7 @@ export function calculate_distance(
   item,
   tn,
   skill,
+  extra_data,
 ) {
   if (item.system.isVehicular && origin_token.actor.type !== "vehicle") {
     return false;
@@ -362,6 +367,7 @@ export function calculate_distance(
         target_token,
         skill,
         tn,
+        extra_data,
       );
     }
   }
@@ -405,6 +411,7 @@ export async function get_tn_from_token(
   target_token,
   origin_token,
   item,
+  extra_data,
 ) {
   const tn = {
     reason: game.i18n.localize("BRSW.Default"),
@@ -424,6 +431,7 @@ export async function get_tn_from_token(
       item,
       tn,
       skill,
+      extra_data,
     );
   }
   if (use_parry_as_tn) {
@@ -437,7 +445,7 @@ export async function get_tn_from_token(
   // Size modifiers
   if (origin_token && target_token) {
     if (!(item?.system?.isVehicular && origin_token.actor.type !== "vehicle")) {
-      getScaleModifier(origin_token, target_token, tn);
+      getScaleModifier(origin_token, target_token, tn, extra_data);
     }
   }
   if (
@@ -458,7 +466,7 @@ export async function get_tn_from_token(
  * Get the scale modifier
  **/
 
-function getScaleModifier(origin_token, target_token, tn) {
+function getScaleModifier(origin_token, target_token, tn, extra_data) {
   const origin_scale_mod = sizeToScale(
     origin_token?.actor?.system?.stats?.size || 1,
   );
@@ -474,6 +482,7 @@ function getScaleModifier(origin_token, target_token, tn) {
     );
     // If the scale mod is negative, check if the attacking actor has the swat ability
     if (scale_mod < 0 && origin_token) {
+      let unignored_penalty = scale_mod * -1;
       const swat = origin_token.actor.items.find((item) => {
         return (
           item.type === "ability" &&
@@ -485,9 +494,15 @@ function getScaleModifier(origin_token, target_token, tn) {
       if (swat) {
         // The swat ability ignores up to 4 points of scale penalties
         const swat_mod = scale_mod < -4 ? 4 : scale_mod * -1;
+        unignored_penalty -= swat_mod;
         tn.modifiers.push(
           new TraitModifier(game.i18n.localize("BRSW.Swat"), swat_mod),
         );
+      }
+      if (unignored_penalty > 0) {
+        //Scale penalties can be ignored by aiming so add it to the total
+        extra_data.total_aiming_ignorable_penalties = extra_data.total_aiming_ignorable_penalties ?? 0;
+        extra_data.total_aiming_ignorable_penalties += unignored_penalty;
       }
     }
   }


### PR DESCRIPTION
## Summary by Sourcery

Adds support for aiming actions that can ignore relevant penalties, such as range or cover penalties. This allows for more accurate shots when aiming, as the character can focus on ignoring certain penalties.

New Features:
- Adds support for aiming actions that can ignore relevant penalties.
- Introduces a new 'Aiming' combat option with a skill modifier and aiming ignore modifier.
- Adds aiming ignore functionality to called shots and cover options.
- Implements the ability for the Marksman edge to ignore aiming penalties.