### PR TITLE
GM actions now respect the group_single property

### DIFF
--- a/betterrolls-swade2/scripts/gm_modifiers.js
+++ b/betterrolls-swade2/scripts/gm_modifiers.js
@@ -8,20 +8,40 @@ import { SettingsUtils } from "./utils.js";
  * @param ev
  */
 export function manage_selectable_gm(ev) {
-  const initial_status = !ev.currentTarget.classList.contains("brws-selected");
-  const value = parseInt(ev.currentTarget.dataset.value);
   ev.currentTarget.classList.toggle("brws-permanent-selected");
   ev.currentTarget.classList.toggle("brws-selected");
-  let value_list = SettingsUtils.getSetting("gm_modifiers");
-  let indice = value_list.indexOf(value);
-  if (indice >= 0 && !initial_status) {
-    value_list.splice(indice, 1);
-  } else if (indice === -1 && initial_status) {
-    value_list.push(value);
+  const is_selected = ev.currentTarget.classList.contains("brws-selected");
+
+  //Handle value modifiers
+  const value = parseInt(ev.currentTarget.dataset.value);
+  if (value != NaN) {
+    let value_list = SettingsUtils.getSetting("gm_modifiers");
+    value_list = value_list.filter((v) => v != null); //Clear out null entries to clean up old, bad data
+    let indice = value_list.indexOf(value);
+    if (indice >= 0 && !is_selected) {
+      //We were selected and now we're not. Remove us from the list
+      value_list.splice(indice, 1);
+    } else if (indice === -1 && is_selected) {
+      //We weren't selected and now we are. Add us to the list
+      value_list.push(value);
+    }
+    // noinspection JSIgnoredPromiseFromCall
+    SettingsUtils.setSetting("gm_modifiers", value_list);
   }
-  // noinspection JSIgnoredPromiseFromCall
-  SettingsUtils.setSetting("gm_modifiers", value_list);
+
+  //Handle GM actions
   let gm_actions = SettingsUtils.getSetting("gm_actions");
+  let action = gm_actions.find((a) => a.name == ev.currentTarget.dataset.actionName);
+  if (action.group_single) {
+    let group_actions = gm_actions.filter((a) => a.group == action.group && action.name != a.name);
+    for (let group_action of group_actions) {
+      let element = document.querySelector(`[data-action-name="${group_action.name}"]`);
+      if (element) {
+        element.classList.remove("brws-permanent-selected");
+        element.classList.remove("brws-selected");
+      }
+    }
+  }
   let selected_actions = [];
   for (let element of document.querySelectorAll(
     "#brsw-gm-actions .brws-permanent-selected",


### PR DESCRIPTION
Fixed the logic around adding and removing gm modifiers

## Summary by Sourcery

Fix the logic for managing GM modifiers and enhance GM actions to respect the 'group_single' property, ensuring proper selection behavior.

Bug Fixes:
- Fix the logic for adding and removing GM modifiers to ensure correct toggling of selection status.

Enhancements:
- Improve the handling of GM actions to respect the 'group_single' property, ensuring only one action in a group can be selected at a time.