### PR TITLE
Added skill_linked_attribute selector

### DIFF
--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -160,26 +160,31 @@ export function get_actions(item, actor) {
  */
 export function check_selector(type, value, item, actor) {
   let selected = false;
-  if (type === "skill") {
+  if (type === "skill" || type === "skill_linked_attribute") {
     if (item.type === "attribute") {
       selected = false;
     } else {
       const skill = item.type === "skill" ? item : get_item_trait(item, actor);
       if (skill) {
-        if (value.slice(0, 5) === "BRSW.") {
-          selected = skill.name
-            .toLowerCase()
-            .includes(game.i18n.localize(value).toLowerCase());
-        } else {
-          selected =
-            skill.name.toLowerCase().includes(value.toLowerCase()) ||
-            skill.name
+        if (type === "skill") {
+          if (value.slice(0, 5) === "BRSW.") {
+            selected = skill.name
               .toLowerCase()
-              .includes(
-                game.i18n
-                  .localize("BRSW.SkillName-" + value.toLowerCase())
-                  .toLowerCase(),
-              );
+              .includes(game.i18n.localize(value).toLowerCase());
+          } else {
+            selected =
+              skill.name.toLowerCase().includes(value.toLowerCase()) ||
+              skill.name
+                .toLowerCase()
+                .includes(
+                  game.i18n
+                    .localize("BRSW.SkillName-" + value.toLowerCase())
+                    .toLowerCase(),
+                );
+          }
+        } else {
+          value = game.i18n.localize(value);
+          selected = skill.system.attribute.toLowerCase().includes(value.toLowerCase())
         }
       }
     }


### PR DESCRIPTION
## Summary by Sourcery

Extend the skill selector to support selecting skills by their linked attribute

New Features:
- Add support for 'skill_linked_attribute' selector type to filter skills based on their linked attribute

Enhancements:
- Modify the check_selector function to handle skill selection by linked attribute with internationalization support