### PR TITLE
Small changes

### DIFF
--- a/betterrolls-swade2/scripts/damage_card.js
+++ b/betterrolls-swade2/scripts/damage_card.js
@@ -210,6 +210,7 @@ async function undo_damage(message) {
       active: render_data.undo_values.shaken,
     });
     await actor.toggleStatusEffect("incapacitated", { active: false });
+    await actor.toggleStatusEffect("dead", { active: false });
   }
   await message.delete();
 }

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -254,6 +254,7 @@ export function expose_item_functions() {
   game.brsw.create_item_card = create_item_card;
   game.brsw.create_item_card_from_id = create_item_card_from_id;
   game.brsw.roll_item = roll_item;
+  game.brsw.create_damage_card = create_damage_card;
 }
 
 /**


### PR DESCRIPTION
## Summary by Sourcery

Enhance damage and item card functionality in the Better Rolls for SWADE module

Bug Fixes:
- Add ability to remove 'dead' status effect when undoing damage

Enhancements:
- Expose create_damage_card function to the global game.brsw namespace for external use