### PR TITLE
Fixed bugs with dmg mod actions

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -1300,7 +1300,7 @@ async function get_damage_mods_from_actions(
       const action_name = action.code.name.includes("BRSW.")
         ? game.i18n.localize(action.code.name)
         : action.code.name;
-      const new_modifier = new DamageModifier(action_name, action.code.dmgMod);
+      const new_modifier = new DamageModifier(action_name, action.code.dmgMod, br_card.actor?.getRollData());
       await new_modifier.evaluate();
       damage_roll.brswroll.modifiers.push(new_modifier);
     }
@@ -1328,7 +1328,7 @@ async function get_damage_mods_from_actions(
     }
     if (action.code.rerollDamageMod && expend_bennie) {
       damage_roll.brswroll.modifiers.push(
-        new DamageModifier(action.code.name, action.code.rerollDamageMod),
+        new DamageModifier(action.code.name, action.code.rerollDamageMod, br_card.actor?.getRollData()),
       );
     }
     if (action.code.multiplyDmgMod) {

--- a/betterrolls-swade2/scripts/modifiers.js
+++ b/betterrolls-swade2/scripts/modifiers.js
@@ -7,14 +7,14 @@ export class TraitModifier {
    * @param {string} label
    * @param {String, Number} expression
    */
-  constructor(label, expression) {
+  constructor(label, expression, rollData) {
     this.name = label;
     this.value = 0;
     this.dice = null;
     if (isNaN(expression)) {
-      if (expression.indexOf("d") > 0) {
+      if (expression.indexOf("d") >= 0 || expression.indexOf("@") >= 0) {
         // This is a die expression
-        this.dice = new Roll(expression);
+        this.dice = new Roll(expression, rollData);
       } else {
         // sourcery skip: no-eval
         this.value = eval(expression); // jshint ignore:line


### PR DESCRIPTION
## Summary by Sourcery

Pass actor roll data when evaluating damage modifiers.

Bug Fixes:
- Allow damage modifier expressions to correctly resolve dice notation (e.g., "1d6").
- Allow damage modifier expressions to correctly resolve attribute references (e.g., "@strength").