### PR TITLE
Missed a spot to pass through roll data

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -1408,6 +1408,7 @@ export async function roll_dmg(
     const new_modifier = new DamageModifier(
       game.i18n.localize("BRSW.ItemPropertiesDmgMod"),
       item.system.actions.dmgMod,
+      br_card.actor?.getRollData()
     );
     await new_modifier.evaluate();
     damage_roll.brswroll.modifiers.push(new_modifier);


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Pass actor roll data to the `DamageModifier` constructor.