### PR TITLE
Fixed the chat popout in v13

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -101,7 +101,7 @@ export class BrCommonCard {
       game.brsw.cascade_count + 1 < cascade_max_cascades
         ? game.brsw.cascade_count + 1
         : 0;
-    new ChatPopout(this.message, { top: top, left: left }).render(true);
+    new CONFIG.ChatMessage.popoutClass({ message: this.message, position: { top: top, left: left } }).render(true);
     this.popup_shown = true;
     this.save().catch(() => {
       console.error("Error saving card data after popup rendering");


### PR DESCRIPTION
## Summary by Sourcery

Fix chat popout instantiation to use the v13 CONFIG.ChatMessage.popoutClass API instead of the old ChatPopout class

Bug Fixes:
- Replace deprecated ChatPopout usage with CONFIG.ChatMessage.popoutClass
- Update constructor arguments to pass message and position per the new API