### PR TITLE
Fixed ROF mod so only one is ever selected

### DIFF
--- a/betterrolls-swade2/scripts/manual_mods_popup.js
+++ b/betterrolls-swade2/scripts/manual_mods_popup.js
@@ -72,8 +72,7 @@ export class ManualModifiersPopup extends HandlebarsApplicationMixin(Application
 
   onModifierSelected(element) {
     element.classList.toggle("brsw-selected");
-    const {type} = element.dataset;
-    const {value} = element.dataset;
+    const { type, value } = element.dataset;
     this.br_card.manual_mods ??= {};
     if (type == "modifier") {
       this.br_card.manual_mods.trait_mods ??= [];
@@ -92,6 +91,11 @@ export class ManualModifiersPopup extends HandlebarsApplicationMixin(Application
         this.br_card.manual_mods.dmg_modifiers.push(value);
       }
     }else if (type == "rof") {
+      for (const rofEl of element.parentElement.querySelectorAll(`[data-type="rof"]`)) {
+        if (rofEl != element) {
+          rofEl.classList.remove("brsw-selected");
+        }
+      }
       this.br_card.manual_mods.rof = element.classList.contains("brsw-selected") ? value : undefined;
     }
     this.br_card.save();


### PR DESCRIPTION
## Summary by Sourcery

Update modifier selection logic to ensure only one ROF modifier can be active at a time and streamline dataset destructuring

Bug Fixes:
- Prevent multiple ROF modifiers from being selected simultaneously by deselecting others when a new one is chosen

Enhancements:
- Combine dataset destructuring for `type` and `value` into a single statement