### PR TITLE
Fixed some bugs with the new illumination logic

### DIFF
--- a/betterrolls-swade2/scripts/actions/combat_options.js
+++ b/betterrolls-swade2/scripts/actions/combat_options.js
@@ -202,14 +202,6 @@ export const COMBAT_OPTIONS = [
         or_selector: [
           {
             selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-Darkvision",
-          },
-          {
-            selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-DarkVision",
-          },
-          {
-            selector_type: "actor_has_ability",
             selector_value: "BRSW.AbilityName-LowLightVision",
           },
           {
@@ -236,14 +228,6 @@ export const COMBAT_OPTIONS = [
         or_selector: [
           {
             selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-Darkvision",
-          },
-          {
-            selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-DarkVision",
-          },
-          {
-            selector_type: "actor_has_ability",
             selector_value: "BRSW.AbilityName-LowLightVision",
           },
           {
@@ -268,18 +252,6 @@ export const COMBAT_OPTIONS = [
     not_selector: [
       {
         or_selector: [
-          {
-            selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-Darkvision",
-          },
-          {
-            selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-DarkVision",
-          },
-          {
-            selector_type: "actor_has_ability",
-            selector_value: "BRSW.AbilityName-LowLightVision",
-          },
           {
             selector_type: "actor_has_ability",
             selector_value: "BRSW.AbilityName-NightVision",

--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -12,7 +12,6 @@ import {
   process_common_actions,
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
-import { get_enabled_gm_actions } from "./gm_actions.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 
 /**
@@ -166,9 +165,6 @@ export async function roll_attribute(br_card, expend_bennie) {
   const macros = [];
   for (const action of br_card.get_selected_actions()) {
     process_common_actions(action.code, extra_data, macros, br_card.actor);
-  }
-  for (const action of get_enabled_gm_actions()) {
-    process_common_actions(action, extra_data, macros, br_card.actor);
   }
   if (expend_bennie) {
     await spend_bennie(br_card.actor);

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -33,7 +33,6 @@ import {
 } from "./utils.js";
 import { create_damage_card } from "./damage_card.js";
 import { ATTRIBUTES_TRANSLATION_KEYS } from "./attribute_card.js";
-import { get_enabled_gm_actions } from "./gm_actions.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { DamageModifier, TraitModifier } from "./modifiers.js";
 import { brAction } from "./actions.js";
@@ -920,9 +919,6 @@ export async function roll_item(br_message, html, expend_bennie, roll_damage) {
       }
     }
     process_common_actions(action.code, extra_data, macros, br_message.actor);
-  }
-  for (const action of get_enabled_gm_actions()) {
-    process_common_actions(action, extra_data, macros, br_message.actor);
   }
   // Check for minimum strength
   if (

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -12,7 +12,6 @@ import {
   process_common_actions,
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
-import { get_enabled_gm_actions } from "./gm_actions.js";
 import { SettingsUtils } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { TraitModifier } from "./modifiers.js";
@@ -204,9 +203,6 @@ export async function roll_skill(br_card, expend_bennie) {
   // Actions
   for (const action of br_card.get_selected_actions()) {
     process_common_actions(action.code, extra_data, macros, br_card.actor);
-  }
-  for (const action of get_enabled_gm_actions()) {
-    process_common_actions(action, extra_data, macros, br_card.actor);
   }
   if (expend_bennie) {
     await spend_bennie(br_card.actor);


### PR DESCRIPTION
## Summary by Sourcery

Fix illumination logic by removing redundant Darkvision selectors from combat options and eliminating unintended GM action processing in roll handlers

Bug Fixes:
- Remove duplicated Darkvision ability checks from combat options filters
- Stop processing GM-enabled actions in attribute, item, and skill roll handlers