### PR TITLE
Null error fix

### DIFF
--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -146,7 +146,7 @@ export function activate_attribute_listeners(app, html) {
  * @param html Html produced
  */
 export function activate_attribute_card_listeners(card, html) {
-  html.querySelector(".brsw-roll-button").addEventListener("click", async (ev) => {
+  html.querySelector(".brsw-roll-button")?.addEventListener("click", async (ev) => {
     await roll_attribute(
       card,
       ev.currentTarget.classList.contains("roll-bennie-button"),

--- a/betterrolls-swade2/scripts/remove_status_cards.js
+++ b/betterrolls-swade2/scripts/remove_status_cards.js
@@ -99,7 +99,7 @@ export function activate_remove_status_card_listeners(
 ) {
   const roll_function =
     card_type === BRSW_CONST.TYPE_UNSHAKE_CARD ? roll_unshaken : roll_unstun;
-  html.querySelector(".brsw-spirit-button, .brsw-roll-button").addEventListener("click", (ev) => {
+  html.querySelector(".brsw-spirit-button, .brsw-roll-button")?.addEventListener("click", (ev) => {
     let spend_bennie = false;
     if (
       ev.currentTarget.classList.contains("roll-bennie-button") ||

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -178,7 +178,7 @@ export function activate_skill_listeners(app, html) {
  * @param html Html produced
  */
 export function activate_skill_card_listeners(br_card, html) {
-  html.querySelector(".brsw-roll-button").addEventListener("click", async (ev) => {
+  html.querySelector(".brsw-roll-button")?.addEventListener("click", async (ev) => {
     await roll_skill(
       br_card,
       ev.currentTarget.classList.contains("roll-bennie-button"),


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Guard addEventListener calls with optional chaining on querySelector results in attribute_card.js, skill_card.js, and remove_status_cards.js to avoid null errors.