### PR TITLE
Fixed the default value of the mod names

### DIFF
--- a/betterrolls-swade2/scripts/manual_mods_popup.js
+++ b/betterrolls-swade2/scripts/manual_mods_popup.js
@@ -32,6 +32,9 @@ export class ManualModifiersPopup extends HandlebarsApplicationMixin(Application
 
   async _prepareContext(_options) {
     const chat_modifiers_names = SettingsUtils.getSetting("chat_modifiers_names");
+    chat_modifiers_names.Damage ||= "BRSW.DmgModifier";
+    chat_modifiers_names.ROF ||= "BRSW.Number_trait_dice";
+    chat_modifiers_names.Trait ||= "BRSW.TraitModifier";
     const trait_mods = this.constructor.TRAIT_MODS.map((t) => ({ value: t, enabled: !!this.br_card.manual_mods?.trait_mods?.find((m) => t == m) }));
     const trait_dice = this.constructor.TRAIT_DICE.map((t) => ({ value: t, enabled: t == this.br_card.manual_mods?.rof }));
     const damage_mods = this.constructor.DAMAGE_MODS.map((t) => ({ value: t, enabled: !!this.br_card.manual_mods?.dmg_modifiers?.find((m) => t == m) }));


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Provide default translation keys for Damage, ROF, and Trait modifiers when missing