### PR TITLE
It's now possible to scroll in the world actions menu

### DIFF
--- a/betterrolls-swade2/css/brsw-styles.css
+++ b/betterrolls-swade2/css/brsw-styles.css
@@ -57,8 +57,13 @@
     width: 100%;
 }
 
+.brsw-world-actions footer {
+    margin-top: auto;
+}
+
 .brsw-action-button-group {
     display: flex;
+    gap: 0.25rem;
 }
 
 .brsw-world-actions button {

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -533,7 +533,8 @@ export class WorldGlobalActions extends HandlebarsApplicationMixin(ApplicationV2
   };
 
   static PARTS = {
-    form: { template: "/modules/betterrolls-swade2/templates/world_globals.html" },
+    form: { template: "/modules/betterrolls-swade2/templates/world_globals/form.hbs" },
+    footer: { template: "/modules/betterrolls-swade2/templates/world_globals/footer.hbs" },
   };
 
   async _prepareContext(options) {
@@ -558,8 +559,11 @@ export class WorldGlobalActions extends HandlebarsApplicationMixin(ApplicationV2
 
   static async formHandler(event, form, formData) {
     let new_world_actions = [];
-    for (let action in foundry.utils.expandObject(formData.object)) {
-      new_world_actions.push(JSON.parse(formData.object[action]));
+    for (let action in formData.object) {
+      const actions = formData.object[action] instanceof Array ? formData.object[action] : [formData.object[action]];
+      for (let action of actions) {
+        new_world_actions.push(JSON.parse(action));
+      }
     }
     await SettingsUtils.setSetting("world_global_actions", new_world_actions);
     register_actions();
@@ -654,7 +658,7 @@ export class WorldGlobalActions extends HandlebarsApplicationMixin(ApplicationV2
       text_area.removeAttribute("name");
     } else {
       action_title.innerHTML = action.name;
-      text_area.name = action.name;
+      text_area.name = action.id;
     }
   }
 

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -559,8 +559,8 @@ export class WorldGlobalActions extends HandlebarsApplicationMixin(ApplicationV2
 
   static async formHandler(event, form, formData) {
     let new_world_actions = [];
-    for (let action in formData.object) {
-      const actions = formData.object[action] instanceof Array ? formData.object[action] : [formData.object[action]];
+    for (let form_action in formData.object) {
+      const actions = formData.object[form_action] instanceof Array ? formData.object[form_action] : [formData.object[form_action]];
       for (let action of actions) {
         new_world_actions.push(JSON.parse(action));
       }

--- a/betterrolls-swade2/templates/world_globals/footer.hbs
+++ b/betterrolls-swade2/templates/world_globals/footer.hbs
@@ -1,26 +1,6 @@
-<div>
-    <h2>{{ localize "BRSW.WorldGlobalMenuLabel" }}</h2>
-    <div class="brsw-action-list">
-        {{#each actions }}<span>
-            <h2 class="twbr:mb-0 twbr:border-none brsw-accordion">
-                <button type="button" data-action="accordion"
-                        class="twbr:p-3 twbr:font-medium twbr:text-white twbr:border
-                        twbr:border-b-0 twbr:border-gray-200 {{# if @first }}twbr:rounded-t-xl{{/if}}
-                        twbr:bg-gray-600 twbr:focus:ring-4 twbr:focus:ring-gray-700
-                        twbr:hover:text-white twbr:hover:bg-gray-700 gap-3">
-                    <span>{{ this.name }}</span>
-                </button>
-            </h2>
-            <div class='brsw-edit-action twbr:p-5 twbr:border twbr:border-b-0 twbr:border-gray-200
-                    twbr:bg-gray-500 brsw-collapsed'>
-                <textarea class='brsw-action-json' name="{{ this.name }}"
-                          rows="9">{{ this.json }}</textarea>
-                <i data-action="trash" class="brsw-red-text fas fa-trash brsw-clickable"></i>
-            </div>
-        </span>{{/each}}
-    </div>
+<footer>
     <button type="button" data-action="newAction"
-            class="brsw-new-action twbr:py-0.5 twbr:px-5 twbr:mr-2 twbr:mt-2 twbr:font-medium
+            class="brsw-new-action twbr:py-0.5 twbr:px-5 twbr:mt-2 twbr:font-medium
             twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border twbr:border-solid
             twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700 twbr:text-gray-800
             twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700">
@@ -28,22 +8,22 @@
     </button>
     <div class="brsw-action-button-group">
         <button type="submit"
-                class="twbr:py-0.5 twbr:px-5 twbr:mr-2 twbr:mb-2 twbr:mt-2
+                class="twbr:py-0.5 twbr:px-5 twbr:mb-2 twbr:mt-2
                 twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border
                 twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700
                 twbr:text-gray-800 twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700">
             <i class="fas fa-save"></i> {{localize "BRSW.Save"}}</button>
         <button type="button" data-action="export"
-                class="brsw-export-json twbr:py-0.5 twbr:px-5 twbr:mr-2 twbr:mb-2 twbr:mt-2
+                class="brsw-export-json twbr:py-0.5 twbr:px-5 twbr:mb-2 twbr:mt-2
                 twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border
                 twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700
                 twbr:text-gray-800 twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700">
             <i class="fas fa-save"></i> {{ localize "BRSW.Export" }}</button>
         <button type="button" data-action="import"
-                class="brsw-import-json twbr:py-0.5 twbr:px-5 twbr:mr-2 twbr:mb-2 twbr:mt-2
+                class="brsw-import-json twbr:py-0.5 twbr:px-5 twbr:mb-2 twbr:mt-2
                 twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border
                 twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700
                 twbr:text-gray-800 twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700">
             <i class="fas fa-file-import"></i> {{ localize "BRSW.Import" }}</button>
     </div>
-</div>
+</footer>

--- a/betterrolls-swade2/templates/world_globals/form.hbs
+++ b/betterrolls-swade2/templates/world_globals/form.hbs
@@ -1,0 +1,24 @@
+<div class="scrollable">
+    <h2>{{ localize "BRSW.WorldGlobalMenuLabel" }}</h2>
+    <div class="brsw-action-list">
+        {{#each actions }}
+        <span>
+            <h2 class="twbr:mb-0 twbr:border-none brsw-accordion">
+                <button type="button" data-action="accordion"
+                        class="twbr:p-3 twbr:font-medium twbr:text-white twbr:border
+                        twbr:border-b-0 twbr:border-gray-200 {{# if @first }}twbr:rounded-t-xl{{/if}}
+                        twbr:bg-gray-600 twbr:focus:ring-4 twbr:focus:ring-gray-700
+                        twbr:hover:text-white twbr:hover:bg-gray-700 gap-3">
+                    <span>{{ this.name }}</span>
+                </button>
+            </h2>
+            <div class='brsw-edit-action twbr:p-5 twbr:border twbr:border-b-0 twbr:border-gray-200
+                    twbr:bg-gray-500 brsw-collapsed'>
+                <textarea class='brsw-action-json' name="{{ this.id }}"
+                          rows="9">{{ this.json }}</textarea>
+                <i data-action="trash" class="brsw-red-text fas fa-trash brsw-clickable"></i>
+            </div>
+        </span>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
## Summary by Sourcery

Enable scrolling in the world global actions menu by refactoring the template into a scrollable form partial and separate footer, updating the application to use these parts, refining form data handling, and adding supporting CSS rules.

New Features:
- Add a scrollable container around the world global actions list to allow scrolling through many entries.

Enhancements:
- Split the world_globals template into distinct form and footer partials and update the application’s PARTS configuration to reference them.
- Improve form handling to iterate over arrayed formData entries and rename text areas to use action IDs instead of names.
- Add CSS rules for footer alignment, scrollable container, and button-group spacing.