### PR TITLE
Reworked roll results display

### DIFF
--- a/betterrolls-swade2/css/brsw-styles.css
+++ b/betterrolls-swade2/css/brsw-styles.css
@@ -128,6 +128,37 @@
     align-items: center;
 }
 
+.brsw-roll-results-wrapper {
+    padding: calc(var(--twbr-spacing) * 1);
+    background-color: var(--twbr-color-gray-500);
+    border: solid 1px var(--twbr-color-gray-700);
+    border-radius: 0.25rem;
+    margin-block: calc(var(--twbr-spacing) * 2);
+}
+
+.brsw-roll-results {
+    display: flex;
+    vertical-align: middle;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.brsw-roll-values {
+    display: flex;
+}
+
+.brsw-roll-value {
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: center;
+    margin-right: calc(var(--twbr-spacing) * 2);
+}
+
+.brsw-roll-value-result-icon {
+    margin-top: 0.3em;
+    -webkit-text-stroke: 0.5px #000;
+}
+
 .brsw-roll-detail-row {
     display: flex;
     justify-content: space-between;
@@ -234,6 +265,10 @@
 
 .brsw-green-text {
     color: lawngreen !important;
+}
+
+.brsw-lime-text {
+    color: lime;
 }
 
 .brsw-row-button {

--- a/betterrolls-swade2/scripts/rolls.js
+++ b/betterrolls-swade2/scripts/rolls.js
@@ -36,13 +36,14 @@ class Die {
 
   // noinspection JSUnusedGlobalSymbols, used in templates
   get result_icon() {
-    if (this.result === null || this.result < 0) {
+    if (this.result === null) {
       return "";
-    }
-    if (this.result < 4) {
-      return "brsw-blue-text fas fa-check fa-2xs";
+    } else if (this.result < 0) {
+      return "brsw-red-text fas fa-xmark fa-xs";
+    } else if (this.result < 4) {
+      return "brsw-lime-text fas fa-check fa-xs";
     } else {
-      return "brsw-blue-text fas fa-check-double fa-2xs";
+      return "brsw-lime-text fas fa-check-double fa-xs";
     }
   }
 

--- a/betterrolls-swade2/templates/trait_roll_partial.html
+++ b/betterrolls-swade2/templates/trait_roll_partial.html
@@ -12,19 +12,18 @@
         {{/each}}
     </div>
 {{/if}}
-<div class="twbr:my-2 twbr:block twbr:p-1 twbr:bg-gray-500 twbr:border twbr:border-solid twbr:border-gray-700
-        twbr:rounded twbr:shadow twbr:hover:ring-2 twbr:hover:ring-offset-1 twbr:hover:cursor-pointer
-        twbr:leading-6 brsw-collapse-button" data-collapse="brsw-roll-detail">
-    <div class="twbr:flex twbr:justify-between twbr:align-middle">
-        <span>
+<div class="brsw-roll-results-wrapper brsw-collapse-button twbr:hover:ring-2 twbr:hover:ring-offset-1 twbr:hover:cursor-pointer" data-collapse="brsw-roll-detail">
+    <div class="brsw-roll-results">
+        <div class="brsw-roll-values">
             {{#each trait_roll.current_roll.dice }}
-                <a class="twbr:mr-2">
-                    <span class="{{this.extra_class}} twbr:text-xl twbr:font-bold twbr:inline-block"  title="{{this.result_text}}">
-                        {{ this.final_total }} <i class="{{ this.result_icon }}"></i>
+                <div class="brsw-roll-value twbr:text-xl twbr:font-bold">
+                    <span class="{{this.extra_class}}"  title="{{this.result_text}}">
+                        {{ this.final_total }}
                     </span>
-                </a>
+                    <i class="{{ this.result_icon }} brsw-roll-value-result-icon"></i>
+                </div>
             {{/each}}
-        </span>
+        </div>
         {{# if show_rerolls }}<span class="twbr:flex twbr:gap-1">
             <button class="brsw-row-button brsw-roll-button brsw-form twbr:py-0.5 twbr:px-1 twbr:font-medium
                     twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border twbr:border-solid


### PR DESCRIPTION
This contains the changes to the roll display I posted on Discord. I'll let you make the final call on if you want it. Here's the post if you want to see how it looks again: https://discord.com/channels/170995199584108546/1052222686463537272/1391959525757812837

## Summary by Sourcery

Revamp the visual presentation of roll results by adding dedicated CSS styles, restructuring the HTML template, and updating icon logic for dice outcomes.

Enhancements:
- Introduce new CSS classes for roll result wrappers, value containers, and icon styling to unify layout and colors
- Restructure trait_roll_partial.html to use a flex-based wrapper and custom classes for rendering roll values and icons
- Refine Die.result_icon logic to simplify null handling, adjust icon sizes, and apply updated color classes for successes and failures