### PR TITLE
Fixed the remaining places where you couldn't spend a benny to reroll

### DIFF
--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -152,6 +152,7 @@ export function activate_attribute_card_listeners(card, html) {
   const roll_buttons = html.querySelectorAll(".brsw-roll-button");
   for (const roll_button of roll_buttons) {
     roll_button.addEventListener("click", async (ev) => {
+      ev.stopPropagation();
       await roll_attribute(
         card,
         ev.currentTarget.classList.contains("roll-bennie-button"),

--- a/betterrolls-swade2/scripts/incapacitation_card.js
+++ b/betterrolls-swade2/scripts/incapacitation_card.js
@@ -8,7 +8,7 @@ import {
   spend_bennie,
 } from "./cards_common.js";
 import { get_owner } from "./damage_card.js";
-import { SettingsUtils } from "./utils.js";
+import { SettingsUtils, addEventListenerAll } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 
 const INJURY_BASE = {
@@ -110,6 +110,7 @@ export function incapacitation_card_hooks() {
  * @param ev
  */
 function roll_incapacitation_clicked(ev, br_card) {
+  ev.stopPropagation();
   let spend_bennie = false;
   if (ev.currentTarget.classList.contains("roll-bennie-button")) {
     spend_bennie = true;
@@ -125,7 +126,7 @@ function roll_incapacitation_clicked(ev, br_card) {
  */
 export function activate_incapacitation_card_listeners(message, html) {
   const br_card = new BrCommonCard(message);
-  html.querySelector(".brsw-vigor-button, .brsw-roll-button")?.addEventListener("click", (ev) => {
+  addEventListenerAll(html, ".brsw-vigor-button, .brsw-roll-button", "click", (ev) => {
     roll_incapacitation_clicked(ev, br_card);
   });
   html.querySelector(".brsw-injury-button")?.addEventListener("click", (ev) => {

--- a/betterrolls-swade2/scripts/remove_status_cards.js
+++ b/betterrolls-swade2/scripts/remove_status_cards.js
@@ -8,7 +8,7 @@ import {
   roll_trait,
   spend_bennie,
 } from "./cards_common.js";
-import { SettingsUtils } from "./utils.js";
+import { SettingsUtils, addEventListenerAll } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { TraitModifier } from "./modifiers.js";
 
@@ -99,7 +99,8 @@ export function activate_remove_status_card_listeners(
 ) {
   const roll_function =
     card_type === BRSW_CONST.TYPE_UNSHAKE_CARD ? roll_unshaken : roll_unstun;
-  html.querySelector(".brsw-spirit-button, .brsw-roll-button")?.addEventListener("click", (ev) => {
+  addEventListenerAll(html, ".brsw-spirit-button, .brsw-roll-button", "click", (ev) => {
+    ev.stopPropagation();
     let spend_bennie = false;
     if (
       ev.currentTarget.classList.contains("roll-bennie-button") ||

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -12,7 +12,7 @@ import {
   process_common_actions,
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
-import { SettingsUtils, measureDistance } from "./utils.js";
+import { SettingsUtils, addEventListenerAll, measureDistance } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { TraitModifier } from "./modifiers.js";
 
@@ -178,7 +178,8 @@ export function activate_skill_listeners(app, html) {
  * @param html Html produced
  */
 export function activate_skill_card_listeners(br_card, html) {
-  html.querySelector(".brsw-roll-button")?.addEventListener("click", async (ev) => {
+  addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
+    ev.stopPropagation();
     await roll_skill(
       br_card,
       ev.currentTarget.classList.contains("roll-bennie-button"),


### PR DESCRIPTION
## Summary by Sourcery

Ensure all roll button clicks correctly support bennie rerolls by preventing event propagation and consolidating listener registration using addEventListenerAll.

Bug Fixes:
- Allow spending bennies for rerolls on incapacitation, status removal, skill, and attribute cards by stopping click event propagation.

Enhancements:
- Use the addEventListenerAll utility for registering click handlers on roll buttons across multiple card scripts.