### PR TITLE
Fixed not being able to make system rolls

### DIFF
--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -13,6 +13,7 @@ import {
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
 import { BrCommonCard } from "./BrCommonCard.js";
+import { addEventListenerAll } from "./utils.js";
 
 /**
 / Translation map for attributes
@@ -134,13 +135,9 @@ async function attribute_click_listener(ev, target) {
  */
 export function activate_attribute_listeners(app, html) {
   const target = app.token || app.object;
-  for (const attribute_label of html.querySelectorAll(".attribute-value")) {
-    const new_label = attribute_label.cloneNode(true);
-    attribute_label.parentNode.replaceChild(new_label, attribute_label);
-    new_label.addEventListener("click", async (ev) => {
-      await attribute_click_listener(ev, target);
-    });
-  }
+  addEventListenerAll(html, ".attribute-value", "click", async (ev) => {
+    await attribute_click_listener(ev, target);
+  });
 }
 
 /**

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -305,21 +305,16 @@ async function item_click_listener(ev, target, currentTarget) {
  */
 export function activate_item_listeners(app, html) {
   const target = app.token || app.object;
-  const item_images = html.querySelectorAll(
+  addEventListenerAll(html,
     ".item-image, .item-img, .name.item-show, span.item>.item-control.item-edit," +
-      " .gear-card .card-header>.item-name, .damage-roll, .item-name>h4," +
-      " .power-header>.item-name, .card-button, .item-control.item-show," +
-      " .power button.item-show, .weapon button.item-show, .edge-hindrance>.item-control" +
-      " .item-control.item-edit, .item-control.item-show, .item.edge-hindrance>.item-show," +
-      " .item>.item-show",
-  );
-  for (const item_image of item_images) {
-    const new_image = item_image.cloneNode(true);
-    item_image.parentNode.replaceChild(new_image, item_image);
-    new_image.addEventListener("click", async (ev) => {
+    " .gear-card .card-header>.item-name, .damage-roll, .item-name>h4," +
+    " .power-header>.item-name, .card-button, .item-control.item-show," +
+    " .power button.item-show, .weapon button.item-show, .edge-hindrance>.item-control" +
+    " .item-control.item-edit, .item-control.item-show, .item.edge-hindrance>.item-show," +
+    " .item>.item-show",
+    "click", async (ev) => {
       await item_click_listener(ev, target, ev.currentTarget);
-    });
-  }
+  });
 }
 
 /**

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -314,9 +314,7 @@ export function activate_item_listeners(app, html) {
       " .item>.item-show",
   );
   for (const item_image of item_images) {
-    const new_image = item_image.cloneNode(true);
-    item_image.parentNode.replaceChild(new_image, item_image);
-    new_image.addEventListener("click", async (ev) => {
+    item_image.addEventListener("click", async (ev) => {
       await item_click_listener(ev, target, ev.currentTarget);
     });
   }

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -12,7 +12,7 @@ import {
   process_common_actions,
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
-import { SettingsUtils, measureDistance } from "./utils.js";
+import { SettingsUtils, addEventListenerAll, measureDistance } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { TraitModifier } from "./modifiers.js";
 
@@ -161,15 +161,11 @@ async function skill_click_listener(ev, target) {
  */
 export function activate_skill_listeners(app, html) {
   const target = app.token || app.object;
-  for (const skill_label of html.querySelectorAll(
+  addEventListenerAll(html,
     ".skill-label a, .skill.item>a, .skill-name, .skill-die",
-  )){
-    const new_label = skill_label.cloneNode(true);
-    skill_label.parentNode.replaceChild(new_label, skill_label);
-    new_label.addEventListener("click", async (ev) => {
-      await skill_click_listener(ev, target);
-    });
-  }
+    "click", async (ev) => {
+    await skill_click_listener(ev, target);
+  });
 }
 
 /**

--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -140,7 +140,7 @@ export async function set_or_update_condition(condition_id, actor) {
 
 export function addEventListenerAll(html, selector, type, listener) {
   html.querySelectorAll(selector).forEach((e) => {
-    e.addEventListener(type, listener);
+    e.addEventListener(type, listener, true);
   });
 }
 

--- a/betterrolls-swade2/scripts/vehicle_card.js
+++ b/betterrolls-swade2/scripts/vehicle_card.js
@@ -88,13 +88,8 @@ export function activate_vehicle_listeners(app, html) {
     "button[data-action='maneuverCheck']",
   );
   if (maneuver_check_button) {
-    const new_button = maneuver_check_button.cloneNode(true);
-    maneuver_check_button.parentNode.replaceChild(
-      new_button,
-      maneuver_check_button,
-    );
-    new_button.addEventListener("click", async (ev) => {
-      await vehicle_click_listener(ev, target);
+    maneuver_check_button.addEventListener("click", async (ev) => {
+      await vehicle_click_listener(ev, target, true);
     });
   }
   const weapon_labels = html.querySelectorAll("a[data-action='showItem']");


### PR DESCRIPTION
## Summary by Sourcery

Fix event listener registration across item, skill, attribute, and vehicle sheets to restore system roll functionality and simplify the code.

Bug Fixes:
- Restore system rolls by ensuring listeners fire correctly on card elements.

Enhancements:
- Replace manual DOM cloning loops with a unified addEventListenerAll helper for cleaner listener attachment.
- Update vehicle action listener to pass the correct parameters without node cloning.