### PR TITLE
Fixed mistake with useCapture introduced with the system roll fix

### DIFF
--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -137,7 +137,7 @@ export function activate_attribute_listeners(app, html) {
   const target = app.token || app.object;
   addEventListenerAll(html, ".attribute-value", "click", async (ev) => {
     await attribute_click_listener(ev, target);
-  });
+  }, true);
 }
 
 /**

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -314,7 +314,7 @@ export function activate_item_listeners(app, html) {
     " .item>.item-show",
     "click", async (ev) => {
       await item_click_listener(ev, target, ev.currentTarget);
-  });
+  }, true);
 }
 
 /**

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -165,7 +165,7 @@ export function activate_skill_listeners(app, html) {
     ".skill-label a, .skill.item>a, .skill-name, .skill-die",
     "click", async (ev) => {
     await skill_click_listener(ev, target);
-  });
+  }, true);
 }
 
 /**

--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -138,9 +138,9 @@ export async function set_or_update_condition(condition_id, actor) {
   });
 }
 
-export function addEventListenerAll(html, selector, type, listener) {
+export function addEventListenerAll(html, selector, type, listener, useCapture=false) {
   html.querySelectorAll(selector).forEach((e) => {
-    e.addEventListener(type, listener, true);
+    e.addEventListener(type, listener, useCapture);
   });
 }
 

--- a/betterrolls-swade2/scripts/vehicle_card.js
+++ b/betterrolls-swade2/scripts/vehicle_card.js
@@ -90,7 +90,7 @@ export function activate_vehicle_listeners(app, html) {
   if (maneuver_check_button) {
     maneuver_check_button.addEventListener("click", async (ev) => {
       await vehicle_click_listener(ev, target, true);
-    });
+    }, true);
   }
   const weapon_labels = html.querySelectorAll("a[data-action='showItem']");
   for (const label of weapon_labels) {


### PR DESCRIPTION
## Summary by Sourcery

Parameterize event listener capture behavior to fix unintended useCapture usage and ensure correct event propagation

Bug Fixes:
- Fix addEventListenerAll to respect a provided useCapture argument instead of always using capture mode
- Update attribute, item, skill, and vehicle card listeners to pass useCapture=true, restoring intended event handling

Enhancements:
- Introduce optional useCapture parameter in addEventListenerAll defaulting to false for greater flexibility