### PR TITLE
Fixed a couple of errors that only affected players

### DIFF
--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -160,11 +160,11 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     }
     // Hide master only sections
     if (!game.user.isGM) {
-      html.querySelector(".brsw-master-only").remove();
+      html.querySelector(".brsw-master-only")?.remove();
     }
     // Hide save macro button from non-owner, non-trusted players
     if (!message.isOwner && !game.user.isTrusted) {
-      html.querySelector(".brsw-owner-trusted-only").remove();
+      html.querySelector(".brsw-owner-trusted-only")?.remove();
     }
     if (Object.keys(message.apps).length < 1) {
       // Don't create popout when rendering popouts.


### PR DESCRIPTION
## Summary by Sourcery

Use optional chaining for removing chat message UI elements to prevent errors when elements are not found for non-GM and non-owner players

Bug Fixes:
- Add "?.remove()" to hide master-only sections without throwing errors when the element is absent
- Add "?.remove()" to hide owner-trusted-only sections without throwing errors when the element is absent