### PR TITLE
Fixed certain elements appear to non-owners

### DIFF
--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -156,15 +156,15 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     activateCardListeners(card, html, message);
     // Hide forms to non-master, non owner
     if (!message.isOwner) {
-      html.querySelector(".brsw-form").classList.add("brsw-collapsed");
+      html.querySelectorAll(".brsw-form").forEach(e => e.classList.add("brsw-collapsed"));
     }
     // Hide master only sections
     if (!game.user.isGM) {
-      html.querySelector(".brsw-master-only")?.remove();
+      html.querySelectorAll(".brsw-master-only").forEach(e => e.remove());
     }
     // Hide save macro button from non-owner, non-trusted players
     if (!message.isOwner && !game.user.isTrusted) {
-      html.querySelector(".brsw-owner-trusted-only")?.remove();
+      html.querySelectorAll(".brsw-owner-trusted-only").forEach(e => e.remove());
     }
     if (Object.keys(message.apps).length < 1) {
       // Don't create popout when rendering popouts.

--- a/betterrolls-swade2/templates/damage_card.html
+++ b/betterrolls-swade2/templates/damage_card.html
@@ -1,7 +1,7 @@
 {{>"modules/betterrolls-swade2/templates/common_card_header.html"}}
 <div class="twbr:flex twbr:justify-between twbr:border-t-1">
     <div>{{{ text }}}</div>
-    <button class="brsw-form brsw-row-button brsw-undo-damage twbr:inline twbr:mt-2 twbr:py-0.5
+    <button class="brsw-form brsw-row-button brsw-undo-damage twbr:mt-2 twbr:py-0.5
             twbr:px-0.5 twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg twbr:border
             twbr:border-solid twbr:focus:ring-4 twbr:focus:ring-gray-700 twbr:text-gray-800
             twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700"


### PR DESCRIPTION
## Summary by Sourcery

Fix UI visibility logic to apply to all matching elements and adjust damage card button styling.

Bug Fixes:
- Hide or remove all relevant chat message form elements for non-owners, non-GM, and non-trusted users by using querySelectorAll instead of querySelector

Enhancements:
- Remove the inline utility class from the undo damage button in the damage card template for consistent styling