### PR TITLE
Fixed header spacing when there is no header image

### DIFF
--- a/betterrolls-swade2/templates/common_card_header.html
+++ b/betterrolls-swade2/templates/common_card_header.html
@@ -39,7 +39,7 @@
       {{# if header.img }}
         <img class="brsw-header-img twbr:w-8 twbr:h-8 twbr:rounded twbr:hover:ring-2
                           twbr:hover:ring-offset-1 twbr:hover:cursor-pointer" src="{{{header.img}}}" alt="Item image">
-        {{/if}}
+      {{/if}}
     </div>
     {{# if show_popup_button }}
       <button class="brsw-popout-button twbr:font-medium twbr:ml-1 twbr:w-8 twbr:h-8 twbr:min-w-8 twbr:align-top
@@ -48,7 +48,7 @@
                       twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700" title='{{ localize "BRSW.PopoutCard" }}'>
         <i class="fas fa-share-from-square"></i>
       </button>
-      {{/if}}
+    {{/if}}
   </div>
 </div>
 <div class="brsw-description {{# if collapse_descriptions }}brsw-collapsed{{/if}}">{{{ description }}}</div>

--- a/betterrolls-swade2/templates/common_card_header.html
+++ b/betterrolls-swade2/templates/common_card_header.html
@@ -35,18 +35,20 @@
     </span>
   </div>
   <div class="twbr:flex">
-    {{# if header.img }}
-    <img class="brsw-header-img twbr:w-8 twbr:h-8 twbr:rounded twbr:hover:ring-2
-                    twbr:hover:ring-offset-1 twbr:hover:cursor-pointer" src="{{{header.img}}}" alt="Item image">
-    {{/if}}
-        {{# if show_popup_button }}
-    <button class="brsw-popout-button twbr:font-medium twbr:ml-1 twbr:w-8 twbr:h-8 twbr:min-w-8 twbr:align-top
-                    twbr:focus:outline-hidden twbr:bg-white twbr:rounded twbr:border twbr:border-solid
-                    twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700 twbr:text-gray-800
-                    twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700" title='{{ localize "BRSW.PopoutCard" }}'>
-      <i class="fas fa-share-from-square"></i>
-    </button>
-    {{/if}}
+    <div class="twbr:w-8 twbr:h-8">
+      {{# if header.img }}
+        <img class="brsw-header-img twbr:w-8 twbr:h-8 twbr:rounded twbr:hover:ring-2
+                          twbr:hover:ring-offset-1 twbr:hover:cursor-pointer" src="{{{header.img}}}" alt="Item image">
+        {{/if}}
+    </div>
+    {{# if show_popup_button }}
+      <button class="brsw-popout-button twbr:font-medium twbr:ml-1 twbr:w-8 twbr:h-8 twbr:min-w-8 twbr:align-top
+                      twbr:focus:outline-hidden twbr:bg-white twbr:rounded twbr:border twbr:border-solid
+                      twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700 twbr:text-gray-800
+                      twbr:border-gray-600 twbr:hover:text-white twbr:hover:bg-gray-700" title='{{ localize "BRSW.PopoutCard" }}'>
+        <i class="fas fa-share-from-square"></i>
+      </button>
+      {{/if}}
   </div>
 </div>
 <div class="brsw-description {{# if collapse_descriptions }}brsw-collapsed{{/if}}">{{{ description }}}</div>


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Maintain placeholder space for the header image when none is provided to prevent layout shifts