### PR TITLE
Disable the roll sound when displaying a card

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -772,7 +772,8 @@ export class BrCommonCard {
     if (whisper_data.whisper) {
       chatData.whisper = whisper_data.whisper;
     }
-    chatData.rolls = [await new Roll("0").roll()];
+    chatData.rolls = [await new Roll("0").evaluate()];
+    chatData.sound = "";
     chatData.rollMode = whisper_data.rollMode;
     return chatData;
   }


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Disable the default roll sound when displaying a card by clearing the sound property and using Roll.evaluate() instead of Roll.roll()