### PR TITLE
Made the popout z-index really big to ensure it never end up lower th…

### DIFF
--- a/betterrolls-swade2/css/brsw-styles.css
+++ b/betterrolls-swade2/css/brsw-styles.css
@@ -371,7 +371,7 @@
     position: absolute;
     background: var(--background);
     padding: 1rem;
-    z-index: 200;
+    z-index: 99999;
 }
 
 #br-card-dialog {


### PR DESCRIPTION
…an a chat card

## Summary by Sourcery

Bug Fixes:
- Increase the popout dialog z-index from 200 to 99999 to prevent it from rendering behind chat cards.