### PR TITLE
Allow addition of event listener to all resist and macro buttons

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -512,7 +512,7 @@ export class BrCommonCard {
   }
 
   get has_feet_buttons() {
-    return this.resist_buttons.length > 0 || this.macro_buttons.length > 0;
+    return this.resist_buttons?.length > 0 || this.macro_buttons?.length > 0;
   }
 
   set_active_actions(actions) {

--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -512,7 +512,7 @@ export class BrCommonCard {
   }
 
   get has_feet_buttons() {
-    return Boolean(this.resist_buttons) && Boolean(this.macro_buttons);
+    return this.resist_buttons.length > 0 || this.macro_buttons.length > 0;
   }
 
   set_active_actions(actions) {

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -465,14 +465,14 @@ export function activate_item_card_listeners(br_card, html) {
     ev.currentTarget.classList.toggle("twbr:bg-red-700");
     ev.currentTarget.classList.toggle("twbr:bg-gray-500");
   });
-  html.querySelector(".brsw-macro-button")?.addEventListener("click", (ev) => {
+  addEventListenerAll(html, ".brsw-macro-button", "click", (ev) => {
     const action =
       br_card.item.system.actions.additional[ev.currentTarget.dataset.macro];
     execute_macro(action, br_card).catch((err) => {
       console.error("Error in macro", err);
     });
   });
-  html.querySelector(".brsw-resist-button")?.addEventListener("click", (ev) => {
+  addEventListenerAll(html, ".brsw-resist-button", "click", (ev) => {
     roll_resist(
       ev.currentTarget.dataset.trait,
       br_card,


### PR DESCRIPTION
Allow addition of event listener to all resist and macro buttons

## Summary by Sourcery

Allow multiple resist and macro buttons on item cards to register click handlers and expose feet controls whenever any resist or macro buttons are present.

Enhancements:
- Attach click handlers to all macro and resist buttons rather than only the first matching element.
- Relax the feet button visibility condition to show when any resist or macro button exists instead of requiring both.