### PR TITLE
If a damage die has a flavor set, we use that in its label

### DIFF
--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -1176,8 +1176,9 @@ async function roll_dmg_target(
         faces: term._faces,
         results: [],
         extra_class: "",
-        label: game.i18n.localize("SWADE.Dmg") + ` (d${term._faces})`,
       };
+      new_die.label = term.flavor ? `${term.flavor.charAt(0).toUpperCase()}${term.flavor.slice(1)}` : game.i18n.localize("SWADE.Dmg");
+      new_die.label += ` (d${term._faces})`;
       for (const result of term.results) {
         new_die.results.push(result.result);
         if (result.result >= term._faces) {


### PR DESCRIPTION
<img width="1040" height="472" alt="flavor" src="https://github.com/user-attachments/assets/5f4725a4-bfe4-454e-8b72-ed331a743d73" />

## Summary by Sourcery

Enhancements:
- Use the die term’s flavor, when present, as the damage label prefix before the die size