### PR TITLE
Fixed some css issues in the settings menu

### DIFF
--- a/betterrolls-swade2/css/brsw-styles.css
+++ b/betterrolls-swade2/css/brsw-styles.css
@@ -346,6 +346,14 @@
     width: 100%;
 }
 
+.brsw-settings-config .form-fields {
+    flex: 1;
+}
+
+.brsw-settings-config .tab {
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+}
 /* Chat tabs */
 .brsw-chat-tab {
     margin-right: 6px;

--- a/betterrolls-swade2/scripts/settings_config.js
+++ b/betterrolls-swade2/scripts/settings_config.js
@@ -24,6 +24,7 @@ export class SettingsConfig extends HandlebarsApplicationMixin(ApplicationV2) {
       title: "BRSW.Settings.Title",
       minimizable: false,
       resizable: true,
+      contentClasses: ["brsw-settings-config"],
     },
     position: { width: 800, height: 700 },
     actions: {

--- a/betterrolls-swade2/templates/setting_partial.html
+++ b/betterrolls-swade2/templates/setting_partial.html
@@ -26,5 +26,5 @@
         {{/if}}
     </div>
 
-    <p class="notes">{{this.hint}}</p>
+    <p class="hint">{{this.hint}}</p>
 </div>


### PR DESCRIPTION
## Summary by Sourcery

Improve layout and styling of the settings configuration dialog for Better Rolls SWADE 2.

Bug Fixes:
- Correct settings hint styling by using the appropriate CSS class for hint text within the settings partial.

Enhancements:
- Adjust settings configuration layout by applying flex behavior to the form fields and adding vertical padding to tabs for better spacing.
- Tag the settings configuration application content with a specific CSS class to enable targeted styling.