### PR TITLE
Fixed click hooks for 5.2

### DIFF
--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -134,7 +134,7 @@ async function attribute_click_listener(ev, target) {
  * @param html Html code
  */
 export function activate_attribute_listeners(app, html) {
-  const target = app.token || app.object;
+  const target = app.token || app.actor || app.object;
   addEventListenerAll(html, ".attribute-value", "click", async (ev) => {
     await attribute_click_listener(ev, target);
   }, true);

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -295,11 +295,19 @@ Hooks.once("diceSoNiceReady", () => {
 
 // Character sheet hooks
 
-["SwadeCharacterSheet", "SwadeNPCSheet", "CharacterSheet"].forEach((name) => {
+["SwadeNPCSheet"].forEach((name) => {
   Hooks.on("render" + name, (app, html, _) => {
     activate_attribute_listeners(app, html[0]);
     activate_skill_listeners(app, html[0]);
     activate_item_listeners(app, html[0]);
+  });
+});
+
+["SwadeActorSheetV2"].forEach((name) => {
+  Hooks.on("render" + name, (app, html, _) => {
+    activate_attribute_listeners(app, html);
+    activate_skill_listeners(app, html);
+    activate_item_listeners(app, html);
   });
 });
 

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -327,7 +327,7 @@ export function activate_item_listeners(app, html) {
  * @param html Html code
  */
 function activate_item_listeners_real(app, html) {
-  const target = app.token || app.object;
+  const target = app.token || app.actor || app.object;
   // It is possible that the Super Powers module had updated the sheet, so we get it again
   addEventListenerAll(
     html,

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -170,7 +170,7 @@ async function skill_click_listener(ev, target) {
  * @param html Html code
  */
 export function activate_skill_listeners(app, html) {
-  const target = app.token || app.object;
+  const target = app.token || app.actor || app.object;
   addEventListenerAll(
     html,
     ".skill-label a, .skill.item>a, .skill-name, .skill-die",


### PR DESCRIPTION
## Summary by Sourcery

Update character sheet hooks and targeting for click listeners to support newer sheet versions.

Bug Fixes:
- Fix click listener targeting by including the actor object in addition to token and object when resolving the roll target.
- Adjust registered render hooks to correctly handle Swade NPC and V2 actor sheets for attribute, skill, and item interactions.