### PR TITLE
Added the concept of a reroll mode and cleaned up Elan and No Mercy

### DIFF
--- a/betterrolls-swade2/scripts/actions/background_edges.js
+++ b/betterrolls-swade2/scripts/actions/background_edges.js
@@ -104,6 +104,7 @@ export const BACKGROUND_EDGES = [
     name: "BRSW.EdgeName-Elan",
     button_name: "BRSW.EdgeName-Elan",
     rerollSkillMod: "+2",
+    rerollMode: "benny",
     selector_type: "actor_has_edge",
     selector_value: "BRSW.EdgeName-Elan",
     defaultChecked: "on",

--- a/betterrolls-swade2/scripts/actions/builtin-actions.js
+++ b/betterrolls-swade2/scripts/actions/builtin-actions.js
@@ -11,8 +11,11 @@ export const SYSTEM_GLOBAL_ACTION = [
     name: "BRSW.EdgeName-NoMercy",
     button_name: "BRSW.EdgeName-NoMercy",
     rerollDamageMod: "+2",
-    selector_type: "actor_has_edge",
-    selector_value: "BRSW.EdgeName-NoMercy",
+    rerollMode: "benny",
+    and_selector: [
+      { selector_type: "actor_has_edge", selector_value: "BRSW.EdgeName-NoMercy" },
+      { selector_type: "item_has_damage", selector_value: "true" },
+    ],
     defaultChecked: "on",
     group: "BRSW.Edges",
   },

--- a/betterrolls-swade2/scripts/attribute_card.js
+++ b/betterrolls-swade2/scripts/attribute_card.js
@@ -170,6 +170,9 @@ export async function roll_attribute(br_card, expend_bennie) {
   for (const action of br_card.get_selected_actions()) {
     process_common_actions(action.code, extra_data, macros, br_card.actor);
   }
+  if (br_card.trait_roll.is_rolled) {
+    br_card.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
+  }
   if (expend_bennie) {
     await spend_bennie(br_card.actor);
   }

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -851,15 +851,19 @@ function get_reroll_options(br_card, extra_data) {
       return;
     }
   }
-  if (br_card.actor.system.stats.globalMods.bennyTrait.length) {
-    for (const mod of br_card.actor.system.stats.globalMods.bennyTrait) {
-      br_card.trait_roll.modifiers.push(
-        new TraitModifier(mod.label, mod.value),
-      );
+  if (br_card.trait_roll.reroll_mode === "benny") {
+    if (br_card.actor.system.stats.globalMods.bennyTrait.length) {
+      for (const mod of br_card.actor.system.stats.globalMods.bennyTrait) {
+        br_card.trait_roll.modifiers.push(
+          new TraitModifier(mod.label, mod.value),
+        );
+      }
     }
   }
   // Modifiers from actions
-  if (extra_data.reroll_modifier) {
+  if (extra_data.reroll_modifier &&
+    (!br_card.trait_roll.reroll_mode ||
+      br_card.trait_roll.reroll_mode === extra_data.reroll_mode)) {
     const new_modifier = new TraitModifier(
       `${extra_data.reroll_modifier.name} (reroll)`,
       extra_data.reroll_modifier.value,
@@ -1295,6 +1299,7 @@ export function process_common_actions(action, extra_data, macros, actor) {
       action_name,
       action.rerollSkillMod,
     );
+    extra_data.reroll_mode = action.rerollMode;
   }
   if (action.rof) {
     extra_data.rof = action.rof;

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -2,7 +2,7 @@
   readTextFromFile, renderTemplate, foundry, canvas, $ */
 /* jshint -W089 */
 
-import { get_item_trait } from "./item_card.js";
+import { get_item_trait, check_for_actions_with_damage } from "./item_card.js";
 import { SYSTEM_GLOBAL_ACTION } from "./actions/builtin-actions.js";
 import { get_roll_options } from "./cards_common.js";
 import {
@@ -414,7 +414,10 @@ export function check_selector(type, value, item, actor) {
       selected = check_document_value(targeted_token.actor, value);
     }
   } else if (type === "item_has_damage") {
-    selected = !!item?.system?.damage;
+    selected = !!item?.system && (!!item.system.damage || check_for_actions_with_damage(item));
+    if (value === "false") {
+      selected = !selected;
+    }
   } else if (type === "range_less_than") {
     const tokens = actor.getActiveTokens();
     if (tokens && game.user.targets.size) {
@@ -674,6 +677,7 @@ export class WorldGlobalActions extends HandlebarsApplicationMixin(
         "raiseDamageFormula",
         "wildDieFormula",
         "rerollSkillMod",
+        "rerollMode",
         "rerollDamageMod",
         "selector_type",
         "selector_value",

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -205,12 +205,11 @@ function get_applicable_effects(item) {
   return effects;
 }
 
-function check_for_actions_with_damage(item) {
-  for (const action in item.system.actions.additional) {
+export function check_for_actions_with_damage(item) {
+  for (const action in item.system.actions?.additional) {
     const current_action = item.system.actions.additional[action];
     if (current_action.type === "damage" && current_action.override) {
       return true;
-      break;
     }
   }
   return false;
@@ -900,6 +899,9 @@ export async function roll_item(br_message, html, expend_bennie, roll_damage) {
   let shots_override; // Override the number of shots used
   let shots_modifier = 0; // Modifier to the number of shots
   const extra_data = { modifiers: [] };
+  if (br_message.trait_roll.is_rolled) {
+    br_message.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
+  }
   if (expend_bennie) {
     await spend_bennie(br_message.actor);
   }
@@ -1351,10 +1353,11 @@ async function get_damage_mods_from_actions(
     if (action.code.apMod) {
       damage_formulas.ap += parseInt(action.code.apMod);
     }
-    if (action.code.rerollDamageMod && expend_bennie) {
+    const reroll_mode = expend_bennie ? "benny" : "free";
+    if (action.code.rerollDamageMod && action.code.rerollMode === reroll_mode) {
       damage_roll.brswroll.modifiers.push(
         new DamageModifier(
-          action.code.name,
+          game.i18n.localize(action.code.name),
           action.code.rerollDamageMod,
           br_card.actor?.getRollData(),
         ),

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -206,6 +206,9 @@ function get_applicable_effects(item) {
 }
 
 export function check_for_actions_with_damage(item) {
+  if (!item.system.actions?.additional) {
+    return false;
+  }
   for (const action in item.system.actions?.additional) {
     const current_action = item.system.actions.additional[action];
     if (current_action.type === "damage" && current_action.override) {
@@ -1354,7 +1357,8 @@ async function get_damage_mods_from_actions(
       damage_formulas.ap += parseInt(action.code.apMod);
     }
     const reroll_mode = expend_bennie ? "benny" : "free";
-    if (action.code.rerollDamageMod && action.code.rerollMode === reroll_mode) {
+    if (action.code.rerollDamageMod &&
+      (!action.code.rerollMode || action.code.rerollMode === reroll_mode)) {
       damage_roll.brswroll.modifiers.push(
         new DamageModifier(
           game.i18n.localize(action.code.name),

--- a/betterrolls-swade2/scripts/skill_card.js
+++ b/betterrolls-swade2/scripts/skill_card.js
@@ -215,6 +215,9 @@ export async function roll_skill(br_card, expend_bennie) {
   for (const action of br_card.get_selected_actions()) {
     process_common_actions(action.code, extra_data, macros, br_card.actor);
   }
+  if (br_card.trait_roll.is_rolled) {
+    br_card.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
+  }
   if (expend_bennie) {
     await spend_bennie(br_card.actor);
   }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a reroll mode concept for trait and damage rolls and align global actions like Elan and No Mercy to only apply in appropriate reroll contexts.

New Features:
- Add a reroll mode flag to trait and damage rolls to distinguish between benny-based rerolls and free rerolls.
- Expose item action damage checks for reuse in selector logic.

Bug Fixes:
- Ensure reroll-only damage modifiers like No Mercy apply only when the item actually deals damage, including via additional actions.

Enhancements:
- Gate benny-specific trait modifiers and reroll skill modifiers behind the appropriate reroll mode to prevent unintended stacking.
- Extend global action configuration to support reroll mode and combined selectors for more precise targeting of effects like Elan and No Mercy.
- Improve the item_has_damage selector to correctly detect items with damage from either base damage or additional actions and support negation via a false value.