### PR TITLE
Added a way to specify operators when checking additional stats. Also added target_additional_stat_

### DIFF
--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -299,14 +299,19 @@ export function check_selector(type, value, item, actor) {
   } else if (type.indexOf("actor_additional_stat_") === 0) {
     const additional_stat = type.slice(22);
     if (actor.system.additionalStats.hasOwnProperty(additional_stat)) {
-      // noinspection EqualityComparisonWithCoercionJS
-      selected = actor.system.additionalStats[additional_stat].value == value;
+      selected = SettingsUtils.check_equality_with_operators(actor.system.additionalStats[additional_stat].value, value);
     }
   } else if (type.indexOf("item_additional_stat_") === 0) {
     const additional_stat = type.slice(21);
     if (item?.system?.additionalStats.hasOwnProperty(additional_stat)) {
-      // noinspection EqualityComparisonWithCoercionJS
-      selected = item.system.additionalStats[additional_stat].value == value;
+      selected = SettingsUtils.check_equality_with_operators(item.system.additionalStats[additional_stat].value, value);
+    }
+  } else if (type.indexOf("target_additional_stat_") === 0) {
+    const additional_stat = type.slice(23);
+    for (const targeted_token of game.user.targets) {
+      if (targeted_token?.actor?.system?.additionalStats.hasOwnProperty(additional_stat)) {
+        selected = selected || SettingsUtils.check_equality_with_operators(targeted_token.actor.system.additionalStats[additional_stat].value, value);
+      }
     }
   } else if (type === "actor_has_joker") {
     selected = actor.hasJoker;

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -310,7 +310,10 @@ export function check_selector(type, value, item, actor) {
     const additional_stat = type.slice(23);
     for (const targeted_token of game.user.targets) {
       if (targeted_token?.actor?.system?.additionalStats.hasOwnProperty(additional_stat)) {
-        selected = selected || SettingsUtils.check_equality_with_operators(targeted_token.actor.system.additionalStats[additional_stat].value, value);
+        if (SettingsUtils.check_equality_with_operators(targeted_token.actor.system.additionalStats[additional_stat].value, value)) {
+          selected = true;
+          break;
+        }
       }
     }
   } else if (type === "actor_has_joker") {

--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -351,7 +351,7 @@ export class SettingsUtils {
   //Compares lhs and rhs for equality
   //This pulls operators from rhs for the comparison or defaults to === if none is present
   static check_equality_with_operators(lhs, rhs) {
-    const [, op = "===", raw] = rhs.match(/^\s*(>=|<=|!==|===|!=|==|=|>|<)?\s*(.*)$/);
+    const [, op = "===", raw] = String(rhs).match(/^\s*(>=|<=|!==|===|!=|==|=|>|<)?\s*(.*)$/);
     const val = raw.trim();
 
     const rhsVal =

--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -347,4 +347,31 @@ export class SettingsUtils {
       ? BRSW2_CONFIG.USER_SETTINGS[key].value
       : BRSW2_CONFIG.USER_SETTINGS[key].default;
   }
+
+  //Compares lhs and rhs for equality
+  //This pulls operators from rhs for the comparison or defaults to === if none is present
+  static check_equality_with_operators(lhs, rhs) {
+    const [, op = "===", raw] = rhs.match(/^\s*(>=|<=|!==|===|!=|==|=|>|<)?\s*(.*)$/);
+    const val = raw.trim();
+
+    const rhsVal =
+      val === "true" && typeof lhs === "boolean" ? true :
+      val === "false" && typeof lhs === "boolean" ? false :
+      val !== "" && !isNaN(val) ? +val :
+      val;
+
+    if ([">", "<", ">=", "<="].includes(op)) {
+      const a = typeof lhs === "number" ? lhs : NaN;
+      const b = typeof rhsVal === "number" ? rhsVal : NaN;
+      return !Number.isNaN(a) && !Number.isNaN(b) && { ">": a > b, ">=": a >= b, "<": a < b, "<=": a <= b }[op];
+    }
+
+    return {
+      "==": lhs == rhsVal,
+      "=": lhs == rhsVal,
+      "!=": lhs != rhsVal,
+      "===": lhs === rhsVal,
+      "!==": lhs !== rhsVal
+    }[op];
+  };
 }

--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -373,5 +373,5 @@ export class SettingsUtils {
       "===": lhs === rhsVal,
       "!==": lhs !== rhsVal
     }[op];
-  };
+  }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add flexible comparison logic for additional stats and extend selectors to support target additional stats.

New Features:
- Allow additional stat checks to specify comparison operators for equality and inequality.
- Support selecting based on targeted tokens' additional stats via the target_additional_stat_ selector prefix.

Enhancements:
- Centralize comparison logic for additional stats into a reusable settings utility helper.