### PR TITLE
Fixed isHeavyWeapon and added location checking to heavy armor

### DIFF
--- a/betterrolls-swade2/scripts/actions/power-generic-modifiers.js
+++ b/betterrolls-swade2/scripts/actions/power-generic-modifiers.js
@@ -61,6 +61,7 @@ export const GENERIC_POWER_MODIFIERS = [
     name: "BRSW.PowerModifiersGenericHeavyWeaponModifier",
     button_name: "BRSW.PowerModifiersGenericHeavyWeaponModifier",
     shotsUsed: "+2",
+    isHeavyWeapon: true,
     selector_type: "item_type",
     selector_value: "power",
     group: groupNameGenericPModifiers,

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -1963,7 +1963,7 @@ function get_template_from_item(item) {
  * Returns true if the target wears a Heavy Armor
  * @param {PlaceableObject} target
  */
-function has_heavy_armor(target, location) {
+function has_heavy_armor(target, location = "torso") {
   // Equipped is equipStatus 3
   return target.document.actor.itemTypes.armor.some(
     (item) =>

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -1180,7 +1180,9 @@ async function roll_dmg_target(
   );
   await roll.evaluate();
   // Heavy armor
-  if (target && !item.system.isHeavyWeapon && has_heavy_armor(target)) {
+  if (target &&
+    (!item.system.isHeavyWeapon && !damage_formulas.heavy_weapon) &&
+    has_heavy_armor(target, damage_formulas.location)) {
     const no_damage_mod = new DamageModifier(
       game.i18n.localize("BRSW.HeavyArmor"),
       -999999,
@@ -1961,16 +1963,14 @@ function get_template_from_item(item) {
  * Returns true if the target wears a Heavy Armor
  * @param {PlaceableObject} target
  */
-function has_heavy_armor(target) {
+function has_heavy_armor(target, location) {
   // Equipped is equipStatus 3
-  const heavy_armor = target.document.actor.items.filter(
+  return target.document.actor.itemTypes.armor.some(
     (item) =>
-      item.type === "armor" &&
       item.system.isHeavyArmor &&
-      item.system.locations.torso &&
+      item.system.locations[location] &&
       item.system.equipStatus === 3,
   );
-  return heavy_armor.length > 0;
 }
 
 async function execute_macro(action, br_card) {


### PR DESCRIPTION
## Summary by Sourcery

Adjust heavy weapon damage handling against heavy armor, including location-aware armor checks and correct heavy weapon flagging on power modifiers.

Bug Fixes:
- Prevent heavy armor from negating damage when attacks are correctly flagged as heavy weapons, including generic power modifiers.

Enhancements:
- Make heavy armor checks location-based so damage resolution respects hit locations rather than assuming torso-only coverage.