### PR TITLE
Bolt can now use called shots. The Drop now applies to all items with damage.

### DIFF
--- a/betterrolls-swade2/scripts/actions/combat_options.js
+++ b/betterrolls-swade2/scripts/actions/combat_options.js
@@ -1,5 +1,26 @@
 /// Actions for combat options in the core rulebook
 
+const CALLED_SHOT_SELECTOR = {
+  or_selector: [
+    {
+      and_selector: [
+        {
+          selector_type: "item_type",
+          selector_value: "power",
+        },
+        {
+          selector_type: "item_name",
+          selector_value: "Bolt",
+        },
+      ]
+    },
+    {
+      selector_type: "item_type",
+      selector_value: "weapon",
+    },
+  ]
+};
+
 export const COMBAT_OPTIONS = [
   {
     id: "AIM",
@@ -46,24 +67,7 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledArm",
     button_name: "BRSW.CalledArm",
     skillMod: -2,
-    or_selector: [
-      {
-        and_selector: [
-          {
-            selector_type: "item_type",
-            selector_value: "power",
-          },
-          {
-            selector_type: "item_name",
-            selector_value: "Bolt",
-          },
-        ]
-      },
-      {
-        selector_type: "item_type",
-        selector_value: "weapon",
-      },
-    ],
+    ...CALLED_SHOT_SELECTOR,
     change_location: "arms",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -74,24 +78,7 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledHand",
     button_name: "BRSW.CalledHand",
     skillMod: -4,
-    or_selector: [
-      {
-        and_selector: [
-          {
-            selector_type: "item_type",
-            selector_value: "power",
-          },
-          {
-            selector_type: "item_name",
-            selector_value: "Bolt",
-          },
-        ]
-      },
-      {
-        selector_type: "item_type",
-        selector_value: "weapon",
-      },
-    ],
+    ...CALLED_SHOT_SELECTOR,
     change_location: "arms",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -104,24 +91,7 @@ export const COMBAT_OPTIONS = [
     skillMod: -4,
     dmgMod: +4,
     dmgOverride: "",
-    or_selector: [
-      {
-        and_selector: [
-          {
-            selector_type: "item_type",
-            selector_value: "power",
-          },
-          {
-            selector_type: "item_name",
-            selector_value: "Bolt",
-          },
-        ]
-      },
-      {
-        selector_type: "item_type",
-        selector_value: "weapon",
-      },
-    ],
+    ...CALLED_SHOT_SELECTOR,
     change_location: "head",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -132,24 +102,7 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledLeg",
     button_name: "BRSW.CalledLeg",
     skillMod: -2,
-    or_selector: [
-      {
-        and_selector: [
-          {
-            selector_type: "item_type",
-            selector_value: "power",
-          },
-          {
-            selector_type: "item_name",
-            selector_value: "Bolt",
-          },
-        ]
-      },
-      {
-        selector_type: "item_type",
-        selector_value: "weapon",
-      },
-    ],
+    ...CALLED_SHOT_SELECTOR,
     change_location: "legs",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,

--- a/betterrolls-swade2/scripts/actions/combat_options.js
+++ b/betterrolls-swade2/scripts/actions/combat_options.js
@@ -37,9 +37,8 @@ export const COMBAT_OPTIONS = [
     button_name: "BRSW.TheDrop",
     skillMod: 4,
     dmgMod: 4,
-    dmgOverride: "",
-    selector_type: "item_type",
-    selector_value: "weapon",
+    selector_type: "item_has_damage",
+    selector_value: "true",
     group: "BRSW.SituationalModifiers",
   },
   {
@@ -47,8 +46,24 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledArm",
     button_name: "BRSW.CalledArm",
     skillMod: -2,
-    selector_type: "item_type",
-    selector_value: "weapon",
+    or_selector: [
+      {
+        and_selector: [
+          {
+            selector_type: "item_type",
+            selector_value: "power",
+          },
+          {
+            selector_type: "item_name",
+            selector_value: "Bolt",
+          },
+        ]
+      },
+      {
+        selector_type: "item_type",
+        selector_value: "weapon",
+      },
+    ],
     change_location: "arms",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -59,8 +74,24 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledHand",
     button_name: "BRSW.CalledHand",
     skillMod: -4,
-    selector_type: "item_type",
-    selector_value: "weapon",
+    or_selector: [
+      {
+        and_selector: [
+          {
+            selector_type: "item_type",
+            selector_value: "power",
+          },
+          {
+            selector_type: "item_name",
+            selector_value: "Bolt",
+          },
+        ]
+      },
+      {
+        selector_type: "item_type",
+        selector_value: "weapon",
+      },
+    ],
     change_location: "arms",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -73,8 +104,24 @@ export const COMBAT_OPTIONS = [
     skillMod: -4,
     dmgMod: +4,
     dmgOverride: "",
-    selector_type: "item_type",
-    selector_value: "weapon",
+    or_selector: [
+      {
+        and_selector: [
+          {
+            selector_type: "item_type",
+            selector_value: "power",
+          },
+          {
+            selector_type: "item_name",
+            selector_value: "Bolt",
+          },
+        ]
+      },
+      {
+        selector_type: "item_type",
+        selector_value: "weapon",
+      },
+    ],
     change_location: "head",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,
@@ -85,8 +132,24 @@ export const COMBAT_OPTIONS = [
     name: "BRSW.CalledLeg",
     button_name: "BRSW.CalledLeg",
     skillMod: -2,
-    selector_type: "item_type",
-    selector_value: "weapon",
+    or_selector: [
+      {
+        and_selector: [
+          {
+            selector_type: "item_type",
+            selector_value: "power",
+          },
+          {
+            selector_type: "item_name",
+            selector_value: "Bolt",
+          },
+        ]
+      },
+      {
+        selector_type: "item_type",
+        selector_value: "weapon",
+      },
+    ],
     change_location: "legs",
     group: "BRSW.AttackOptionCalledShot",
     group_single: true,


### PR DESCRIPTION
## Summary by Sourcery

Extend combat option selectors to support called shots with the Bolt power and to apply The Drop to any item that deals damage.

Enhancements:
- Allow called shot combat options to be used with both weapons and the Bolt power.
- Broaden The Drop combat option so it applies to all items that have damage instead of only weapons.