### PR TITLE
We now await the import and set so that the window is updated after

### DIFF
--- a/betterrolls-swade2/scripts/BrCommonCard.js
+++ b/betterrolls-swade2/scripts/BrCommonCard.js
@@ -473,7 +473,7 @@ export class BrCommonCard {
         this.resist_buttons.push({
           name: current_action.name,
           trait: current_action.override || this.skill.name,
-          trait_mod: current_action.skillMod,
+          trait_mod: current_action.modifier,
         });
       }
     }

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -793,9 +793,8 @@ async function import_global_actions(app) {
           if (!form.data.files.length) {
             return ui.notifications.error("You did not upload a data file!");
           }
-          await foundry.utils.readTextFromFile(form.data.files[0]).then(async (json) => {
-            await SettingsUtils.setSetting("world_global_actions", JSON.parse(json));
-          });
+          const jsonText = await foundry.utils.readTextFromFile(form.data.files[0]);
+          await SettingsUtils.setSetting("world_global_actions", JSON.parse(jsonText));
           app.render(true);
         },
       },

--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -788,13 +788,13 @@ async function import_global_actions(app) {
         icon: "fas fa-file-import",
         label: "Import",
         action: "import",
-        callback: (event, target, dialog) => {
+        callback: async (event, target, dialog) => {
           const form = dialog.element.querySelector("form");
           if (!form.data.files.length) {
             return ui.notifications.error("You did not upload a data file!");
           }
-          foundry.utils.readTextFromFile(form.data.files[0]).then((json) => {
-            SettingsUtils.setSetting("world_global_actions", JSON.parse(json));
+          await foundry.utils.readTextFromFile(form.data.files[0]).then(async (json) => {
+            await SettingsUtils.setSetting("world_global_actions", JSON.parse(json));
           });
           app.render(true);
         },


### PR DESCRIPTION
This fixes a timing issue where we would render the window before the set was complete which would make it look like the import failed. If you hit save at this point, it would then stomp over the import since that's what was in the form data.

Also fixed a deprecation warning.

## Summary by Sourcery

Ensure global action imports complete before re-rendering and align card resistance modifier usage with the current action data.

Bug Fixes:
- Wait for global action settings to be saved before re-rendering the window to avoid showing stale data and overwriting imports.
- Use the correct modifier field when building resistance buttons to fix incorrect trait modifiers on cards.