### PR TITLE
Removed the wound cap setting and replaced it with the system setting

### DIFF
--- a/betterrolls-swade2/lang/ca.json
+++ b/betterrolls-swade2/lang/ca.json
@@ -317,8 +317,6 @@
     "BRSW.WorldGlobalMenuHint": "Fes servir aquesta finesta per crear accions globals per aquest món (World)",
     "BRSW.WorldGlobalMenuLabel": "Accions globals de món",
     "BRSW.Wound": "Ferida",
-    "BRSW.WoundCap": "Límit de ferides",
-    "BRSW.WoundCapHint": "Si aquest camp té un número s'activarà la regla de límit de ferides, si és 0 o està en blanc es desactivarà. (World)",
     "BRSW.Wounds": "Ferides",
     "BRSW.WoundsOrFatigueIgnored": "Ignorar ferides i fatiga",
     "BRWS.ConvictionRoll": "Tirada de convicció",

--- a/betterrolls-swade2/lang/de.json
+++ b/betterrolls-swade2/lang/de.json
@@ -320,8 +320,6 @@
     "BRSW.WorldGlobalMenuHint": "Verwalte die globalen Aktionen dieser Welt. (Welt)",
     "BRSW.WorldGlobalMenuLabel": "Globale Aktionen (Welt)",
     "BRSW.Wound": "Wunde",
-    "BRSW.WoundCap": "Wundobergrenze",
-    "BRSW.WoundCapHint": "Die hier eingetragene Nummer wird als Wundobergrenze angenommen. Bei einem leeren Feld gelten die Standardregeln. (Welt)",
     "BRSW.Wounds": "Wunden",
     "BRSW.WoundsOrFatigueIgnored": "Ignorierte Wunden oder Erschöpfung",
     "I18N.MAINTAINERS": [

--- a/betterrolls-swade2/lang/en.json
+++ b/betterrolls-swade2/lang/en.json
@@ -509,8 +509,6 @@
   "BRSW.WorldGlobalMenuHint": "Use this window to create global actions for this world. (World)",
   "BRSW.WorldGlobalMenuLabel": "World Global actions",
   "BRSW.Wound": "Wound",
-  "BRSW.WoundCap": "Wound Cap",
-  "BRSW.WoundCapHint": "If you put a number here it will be activate the wound cap rule with that number as a cap, if it is either zero or blank it will use default rules. (World)",
   "BRSW.Wounds": "Wounds",
   "BRSW.WoundsOrFatigueIgnored": "Wounds or Fatigue ignored",
   "BRSW.Shots": "Shots",

--- a/betterrolls-swade2/lang/es.json
+++ b/betterrolls-swade2/lang/es.json
@@ -318,8 +318,6 @@
     "BRSW.WorldGlobalMenuHint": "Usa esta ventana para crear acciones globales de mundo. (Mundo)",
     "BRSW.WorldGlobalMenuLabel": "Acciones globales de mundo",
     "BRSW.Wound": "Herida",
-    "BRSW.WoundCap": "Límite de heridas",
-    "BRSW.WoundCapHint": "Si este campo tiene un número se activará la regla de límite de heridas, si es 0 o está en blanco se desactivará. (Mundo)",
     "BRSW.Wounds": "Heridas",
     "I18N.MAINTAINERS": [
         "Javi Rivera"

--- a/betterrolls-swade2/lang/fr.json
+++ b/betterrolls-swade2/lang/fr.json
@@ -314,8 +314,6 @@
     "BRSW.WorldGlobalMenuHint": "Utiliser cette fenêtre d'options pour créer des actions globales spécifiques à ce monde.",
     "BRSW.WorldGlobalMenuLabel": "Actions globales au monde",
     "BRSW.Wound": "Blessure",
-    "BRSW.WoundCap": "Limite de Blessures",
-    "BRSW.WoundCapHint": "Seuil pour la Limite de Blessures, et s'il est zéro ou vide, utilise le seuil standard de quatre.",
     "BRSW.Wounds": "Blessures",
     "I18N.MAINTAINERS": [
         "Cyril Ronseaux"

--- a/betterrolls-swade2/lang/pt-BR.json
+++ b/betterrolls-swade2/lang/pt-BR.json
@@ -319,8 +319,6 @@
     "BRSW.WorldGlobalMenuHint": "Use essa janela para criar ações globais para esse mundo (Mundo)",
     "BRSW.WorldGlobalMenuLabel": "Ações globais do Mundo",
     "BRSW.Wound": "Ferimento",
-    "BRSW.WoundCap": "Limite de Ferimentos",
-    "BRSW.WoundCapHint": "Adicionar um número aqui ativará a regra de limite de ferimentos, o valor adicionado será o limite. Se o valor for zero ou branco será utilizado a regra padrão. (Mundo)",
     "BRSW.Wounds": "Ferimentos",
     "BRSW.WoundsOrFatigueIgnored": "Ferimentos ou Fadiga ignorados",
     "I18N.MAINTAINERS": [

--- a/betterrolls-swade2/lang/pt.json
+++ b/betterrolls-swade2/lang/pt.json
@@ -299,8 +299,6 @@
     "BRSW.WorldGlobalMenuHint": "Use esta janela para criar ações globais para este mundo (Mundo)",
     "BRSW.WorldGlobalMenuLabel": "Ações globais do Mundo",
     "BRSW.Wound": "Ferimento",
-    "BRSW.WoundCap": "Limite de Ferimentos",
-    "BRSW.WoundCapHint": "Adicionar um número aqui ativará a regra de limite de ferimentos, o valor adicionado será o limite. Se o valor for zero ou branco será utilizado a regra padrão. (Mundo)",
     "BRSW.Wounds": "Ferimentos",
     "BRSW.WoundsOrFatigueIgnored": "Ferimentos ou Fadiga ignorados",
     "Better Rolls": "Better Rolls"

--- a/betterrolls-swade2/scripts/brsw2-init.js
+++ b/betterrolls-swade2/scripts/brsw2-init.js
@@ -545,14 +545,6 @@ function register_settings_version2() {
     config: false,
     scope: "world",
   });
-  SettingsUtils.registerSetting("wound-cap", {
-    name: game.i18n.localize("BRSW.WoundCap"),
-    hint: game.i18n.localize("BRSW.WoundCapHint"),
-    default: 0,
-    scope: "world",
-    type: Number,
-    config: false,
-  });
   SettingsUtils.registerSetting("chat_modifiers_names", {
     name: "Chat Modifiers Names",
     hint: "",

--- a/betterrolls-swade2/scripts/damage_card.js
+++ b/betterrolls-swade2/scripts/damage_card.js
@@ -36,8 +36,8 @@ export async function create_damage_card(
     shaken: actor.system.status.isShaken,
   };
   let wounds = Math.floor(damage / 4);
-  if (SettingsUtils.getSetting("wound-cap")) {
-    wounds = Math.min(wounds, SettingsUtils.getSetting("wound-cap"));
+  if (game.settings.get('swade', 'woundCap')) {
+    wounds = Math.min(wounds, 4);
   }
   // noinspection JSUnresolvedVariable
   const can_soak = wounds || actor.system.status.isShaken;

--- a/betterrolls-swade2/scripts/optional_rules.js
+++ b/betterrolls-swade2/scripts/optional_rules.js
@@ -47,9 +47,8 @@ export class OptionalRulesConfiguration extends HandlebarsApplicationMixin(Appli
         enabled: enable_rules.indexOf(rule) > -1,
       });
     }
-    let wound_cap = SettingsUtils.getSetting("wound-cap");
     // noinspection JSValidateTypes
-    return { rules: rules, wound_cap: wound_cap };
+    return { rules: rules };
   }
 
   static async formHandler(event, form, formData) {
@@ -60,6 +59,5 @@ export class OptionalRulesConfiguration extends HandlebarsApplicationMixin(Appli
       }
     }
     await SettingsUtils.setSetting("optional_rules_enabled", enabled);
-    await SettingsUtils.setSetting("wound-cap", formData.object.wound_cap);
   }
 }

--- a/betterrolls-swade2/templates/optional_rules.hbs
+++ b/betterrolls-swade2/templates/optional_rules.hbs
@@ -7,19 +7,6 @@
                     {{#if this.enabled}}checked="checked"{{/if}}>
                 <label>{{ this.name }}</label></td>
         </tr>{{/ each}}
-        <tr class="form-group">
-            <td>
-                <label>{{ localize "BRSW.WoundCap" }}</label>
-            </td>
-            <td class="form-fields">
-                <input type="text" name="wound_cap" value="{{ wound_cap}}" data-dtype="Number">
-            </td>
-        </tr>
-        <tr>
-            <td colspan="2">
-                <p class="notes">{{ localize "BRSW.WoundCapHint" }}</p>
-            </td>
-        </tr>
     </table>
     <button type="submit"><i class="far fa-save"></i>{{localize "BRSW.Save"}}</button>
 </div>


### PR DESCRIPTION
## Summary by Sourcery

Align wound cap handling with the core SWADE system setting and remove the module-specific configuration.

Enhancements:
- Replace module-specific wound cap logic with the core SWADE woundCap system flag, capping applied wounds at 4 when enabled.
- Remove the optional rules UI and configuration storage related to the custom wound cap setting, along with its localization entries.