### PR TITLE
Fixed the check in check_document_value to properly handle types

### DIFF
--- a/betterrolls-swade2/scripts/global_actions.js
+++ b/betterrolls-swade2/scripts/global_actions.js
@@ -460,7 +460,7 @@ function check_document_value(document, value) {
   const [path, result] = value.split("=");
   const data = foundry.utils.getProperty(document, path);
   // noinspection EqualityComparisonWithCoercionJS
-  return data == result;
+  return result != undefined ? SettingsUtils.check_equality_with_operators(data, result) : !!data;
 }
 
 // noinspection JSPrimitiveTypeWrapperUsage


### PR DESCRIPTION
## Summary by Sourcery

Update document value checking to support operator-aware comparisons and truthiness checks when no explicit value is provided.

Bug Fixes:
- Correct document value comparison logic to handle typed and operator-based evaluations instead of relying on loose equality.

Enhancements:
- Fallback to truthiness evaluation when no comparison value is specified in document checks.