### PR TITLE
Fixes to rolls

### DIFF
--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -896,17 +896,30 @@ async function get_reroll_options(br_card, extra_data) {
  * @param {BrCommonCard} br_card
  * @param {Roll} roll
  */
-async function show_3d_dice(br_card, roll) {
-  if (br_card.trait_roll.wild_die) {
+export async function roll_dice(message, brswroll, roll) {
+  if (game.dice3d) {
+    await show_3d_dice(message, brswroll, roll);
+  } else {
+    game.audio.play(CONFIG.sounds.dice, { context: game.audio.interface });
+  }
+}
+
+/**
+ * Show the 3d dice for a trait roll
+ * @param {BrCommonCard} br_card
+ * @param {Roll} roll
+ */
+async function show_3d_dice(message, brswroll, roll) {
+  if (brswroll.wild_die) {
     set_wild_die_theme(roll.dice[roll.dice.length - 1]);
   }
   let users = null;
-  if (br_card.message.whisper.length > 0) {
-    users = br_card.message.whisper;
+  if (message.whisper.length > 0) {
+    users = message.whisper;
   }
-  const { blind } = br_card.message;
+  const { blind } = message;
   // Dice buried in modifiers.
-  for (const modifier of br_card.trait_roll.modifiers) {
+  for (const modifier of brswroll.modifiers) {
     if (modifier.dice && modifier.dice instanceof Roll) {
       // noinspection ES6MissingAwait
       game.dice3d.showForRoll(modifier.dice, game.user, true, users, blind);
@@ -1026,9 +1039,7 @@ export async function roll_trait(br_card, trait_dice, dice_label, extra_data) {
   const roll = new Roll(roll_string);
   await roll.evaluate();
   await br_card.trait_roll.add_roll(roll);
-  if (game.dice3d) {
-    await show_3d_dice(br_card, roll);
-  }
+  await roll_dice(br_card.message, br_card.trait_roll, roll);
   await br_card.render();
   await br_card.save();
 }
@@ -1102,18 +1113,8 @@ async function add_modifier(br_card, modifier) {
     const name = modifier.label || game.i18n.localize("BRSW.ManuallyAdded");
     const new_mod = new TraitModifier(name, modifier.value);
     await new_mod.evaluate();
-    if (game.dice3d && new_mod.dice) {
-      let users = null;
-      if (br_card.message.whisper.length > 0) {
-        users = br_card.message.whisper;
-      }
-      await game.dice3d.showForRoll(
-        new_mod.dice,
-        game.user,
-        true,
-        users,
-        br_card.message.blind,
-      );
+    if (new_mod.dice) {
+      await roll_dice(br_card.message, br_card.trait_roll, new_mod.dice);
     }
     br_card.trait_roll.modifiers.push(new_mod);
     await br_card.trait_roll.recalculate_trait_results();

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -892,8 +892,9 @@ async function get_reroll_options(br_card, extra_data) {
 }
 
 /**
- * Show the 3d dice for a trait roll
- * @param {BrCommonCard} br_card
+ * Handle the feedback of rolling the dice
+ * @param {ChatMessage} message
+ * @param {BRWSRoll} brswroll
  * @param {Roll} roll
  */
 export async function roll_dice(message, brswroll, roll) {
@@ -905,8 +906,9 @@ export async function roll_dice(message, brswroll, roll) {
 }
 
 /**
- * Show the 3d dice for a trait roll
- * @param {BrCommonCard} br_card
+ * Show the 3d dice for a roll
+ * @param {ChatMessage} message
+ * @param {BRWSRoll} brswroll
  * @param {Roll} roll
  */
 async function show_3d_dice(message, brswroll, roll) {

--- a/betterrolls-swade2/scripts/cards_common.js
+++ b/betterrolls-swade2/scripts/cards_common.js
@@ -853,7 +853,7 @@ async function get_new_roll_options(
  * @param {BrCommonCard} br_card - The card to get the options from
  * @param {Object} extra_data
  */
-function get_reroll_options(br_card, extra_data) {
+async function get_reroll_options(br_card, extra_data) {
   // Reroll, clear out old reroll mods so we don't double add
   // This doesn't use filter() because the array is referenced elsewhere
   br_card.trait_roll.modifiers.splice(
@@ -861,6 +861,14 @@ function get_reroll_options(br_card, extra_data) {
     br_card.trait_roll.modifiers.length,
     ...br_card.trait_roll.modifiers.filter((mod) => !mod.isReroll)
   );
+  //Reroll any dice modifiers
+  const modifiers = br_card.trait_roll.modifiers;
+  for (let i = 0; i < modifiers.length; ++i) {
+    if (modifiers[i].dice) {
+      modifiers[i] = new TraitModifier(modifiers[i].name, modifiers[i].dice.formula);
+      await modifiers[i].evaluate();
+    }
+  }
   // Modifiers from effects
   if (br_card.trait_roll.reroll_mode === "benny") {
     for (const mod of br_card.actor.system.stats.globalMods.bennyTrait) {
@@ -986,7 +994,7 @@ export async function roll_trait(br_card, trait_dice, dice_label, extra_data) {
   } else {
     roll_options.modifiers = br_card.trait_roll.modifiers;
     roll_options.rof = br_card.trait_roll.rof;
-    get_reroll_options(br_card, extra_data);
+    await get_reroll_options(br_card, extra_data);
   }
   let roll_string = create_roll_string(trait_dice, roll_options.rof);
   // Wild Die

--- a/betterrolls-swade2/scripts/incapacitation_card.js
+++ b/betterrolls-swade2/scripts/incapacitation_card.js
@@ -234,6 +234,9 @@ export async function create_injury_card(token_id, reason) {
   // First roll
   let first_roll = new Roll("2d6");
   await first_roll.evaluate();
+  if (!game.dice3d) {
+    game.audio.play(CONFIG.sounds.dice, { context: game.audio.interface });
+  }
   if (game.dice3d) {
     // noinspection ES6MissingAwait
     await game.dice3d.showForRoll(first_roll, game.user, true);

--- a/betterrolls-swade2/scripts/item_card.js
+++ b/betterrolls-swade2/scripts/item_card.js
@@ -16,6 +16,7 @@ import {
   has_joker,
   process_common_actions,
   process_minimum_str_modifiers,
+  roll_dice,
 } from "./cards_common.js";
 import {
   FIGHTING_SKILLS,
@@ -1267,34 +1268,13 @@ async function roll_dmg_target(
     ].label = game.i18n.localize("BRSW.Raise");
   }
   current_damage_roll.label = defense_values.name;
-  // Dice so nice
-  if (game.dice3d) {
-    // Dice buried in modifiers.
-    let users = null;
-    if (message.whisper.length > 0) {
-      users = message.whisper;
+  const damage_theme = SettingsUtils.getUserSetting("damageDieTheme");
+  if (damage_theme !== "None") {
+    for (const die of roll.dice) {
+      die.options.colorset = damage_theme;
     }
-    for (const modifier of damage_roll.brswroll.modifiers) {
-      if (modifier.dice) {
-        // noinspection ES6MissingAwait
-        game.dice3d.showForRoll(
-          modifier.dice,
-          game.user,
-          true,
-          users,
-          message.blind,
-        );
-      }
-    }
-    const damage_theme = SettingsUtils.getUserSetting("damageDieTheme");
-    if (damage_theme !== "None") {
-      for (const die of roll.dice) {
-        die.options.colorset = damage_theme;
-      }
-    }
-    // noinspection ES6MissingAwait
-    await game.dice3d.showForRoll(roll, game.user, true, users, message.blind);
   }
+  await roll_dice(message, damage_roll.brswroll, roll);
   current_damage_roll.damage_result = calculate_damage_results(
     current_damage_roll.brswroll.rolls,
   );
@@ -1627,20 +1607,14 @@ async function add_damage_dice(br_card, index) {
   render_data.damage_rolls[index].damage_result = calculate_damage_results(
     damage_rolls.rolls,
   );
-  if (game.dice3d) {
-    const damage_theme = SettingsUtils.getUserSetting("damageDieTheme");
-    if (damage_theme !== "None") {
-      roll.dice.forEach((die) => {
-        die.options.colorset = damage_theme;
-      });
-    }
-    let users = null;
-    if (br_card.message.whisper.length > 0) {
-      users = br_card.message.whisper;
-    }
-    // noinspection ES6MissingAwait,JSIgnoredPromiseFromCall
-    game.dice3d.showForRoll(roll, game.user, true, users);
+
+  const damage_theme = SettingsUtils.getUserSetting("damageDieTheme");
+  if (damage_theme !== "None") {
+    roll.dice.forEach((die) => {
+      die.options.colorset = damage_theme;
+    });
   }
+  await roll_dice(br_card.message, render_data.damage_rolls[index].brswroll, roll);
   // noinspection JSIgnoredPromiseFromCall
   await update_message(br_card, render_data);
 }


### PR DESCRIPTION
* Fixed dice modifiers not rerolling
* Refactored rolls to go through roll_dice rather than everywhere handling dice3d manually
* Added the dice roll SFX when rolling when not using DSN

## Summary by Sourcery

Fix dice rerolls and centralize dice rolling logic through a shared helper that also triggers sound effects when 3D dice are unavailable.

Bug Fixes:
- Ensure trait roll rerolls correctly regenerate any dice-based modifiers instead of reusing old results.

Enhancements:
- Introduce a roll_dice helper to unify 3D dice display and fallback audio across trait, damage, and modifier rolls.
- Apply damage die theme coloring consistently before rolling and showing dice for damage and bonus damage rolls.
- Play dice sound effects when rolling injury and other dice in environments without 3D dice support.