### PR TITLE
Fixed an error when measuring distance with very small tokens

### DIFF
--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -169,8 +169,8 @@ function getTokenGridSpaces(token) {
       y: token.bounds.top + halfGrid,
     };
     const dimensions = {
-      width: Math.round(token.document.width),
-      height: Math.round(token.document.height),
+      width: Math.max(1, Math.round(token.document.width)),
+      height: Math.max(1, Math.round(token.document.height)),
     };
 
     for (let i = 0; i < dimensions.width; ++i) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent distance and grid-space measurement errors for tokens whose rounded width or height would otherwise be zero.