### PR TITLE
Merging from main

### DIFF
--- a/betterrolls-swade2/scripts/utils.js
+++ b/betterrolls-swade2/scripts/utils.js
@@ -169,8 +169,8 @@ function getTokenGridSpaces(token) {
       y: token.bounds.top + halfGrid,
     };
     const dimensions = {
-      width: Math.round(token.document.width),
-      height: Math.round(token.document.height),
+      width: Math.max(1, Math.round(token.document.width)),
+      height: Math.max(1, Math.round(token.document.height)),
     };
 
     for (let i = 0; i < dimensions.width; ++i) {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Prevent getTokenGridSpaces from producing zero-sized dimensions by clamping token width and height to a minimum of one grid space.