### PR TITLE
Changed the ownership check to be on the speaker actor since it's no longer reliable on the message

### DIFF
--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -139,7 +139,7 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     const card = new BrCommonCard(message);
     activateCardListeners(card, html, message);
     // Hide forms to non-master, non owner
-    if (!message.isOwner) {
+    if (!message.speakerActor?.isOwner) {
       html
         .querySelectorAll(".brsw-form")
         .forEach((e) => e.classList.add("brsw-collapsed"));
@@ -149,7 +149,7 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
       html.querySelectorAll(".brsw-master-only").forEach((e) => e.remove());
     }
     // Hide save macro button from non-owner, non-trusted players
-    if (!message.isOwner && !game.user.isTrusted) {
+    if (!message.speakerActor?.isOwner && !game.user.isTrusted) {
       html
         .querySelectorAll(".brsw-owner-trusted-only")
         .forEach((e) => e.remove());

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -263,7 +263,7 @@ export function activate_common_listeners(br_card, html) {
         });
       });
   }
-  if (br_card.message.isOwner) {
+  if (br_card.message.speakerActor?.isOwner) {
     html
       .querySelector(".brsw-selected-actions")
       ?.addEventListener("click", () => {
@@ -273,7 +273,7 @@ export function activate_common_listeners(br_card, html) {
   // Collapsible
   manage_collapsables(html, br_card.message);
   // Old rolls
-  if (br_card.message.isOwner) {
+  if (br_card.message.speakerActor?.isOwner) {
     const old_rolls = html.querySelectorAll(".brsw-old-roll");
     for (const old_roll of old_rolls) {
       old_roll.addEventListener("click", async (ev) => {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure visibility and interaction controls for chat card forms and actions respect the speaker actor's ownership when message ownership is unreliable.