### PR TITLE
Auto roll fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 5.0.5
+* Ensure we have a skill before rolling item and damage before rolling damage when using auto-roll
+
 # Version 5.0.4
 * Properly fixed the ownership bug with chat messages
 

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -333,8 +333,10 @@ async function item_click_listener(ev, target, currentTarget) {
   });
   if (action.includes("dialog")) {
     game.brsw.dialog.show_card(br_card);
-  } else if (action.includes("trait")) {
+  } else if (br_card.skill && action.includes("trait")) {
     await roll_item(br_card, "", false, action.includes("damage"));
+  } else if (br_card.damage && action.includes("damage")) {
+    await roll_dmg(br_card, "");
   }
   // Shortcut for rolling damage
   if (ev.target.classList.contains("damage-roll")) {


### PR DESCRIPTION
## Summary by Sourcery

Guard auto-roll item and damage actions based on card properties to prevent invalid rolls.

Bug Fixes:
- Require a skill before auto-rolling an item trait and require damage data before auto-rolling damage.

Documentation:
- Document the auto-roll guard fix in the changelog for version 5.0.5.