### PR TITLE
Changed targets to be saved as uuids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 5.0.6
+* Changed targets to be saved as uuids
+
 # Version 5.0.5
 * Ensure we have a skill before rolling item and damage before rolling damage when using auto-roll
 

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -283,8 +283,8 @@ export class BrCommonCard {
 
   get targets() {
     const target_array = [];
-    for (const target_id in this.target_ids) {
-      target_array.push(canvas.tokens.get(target_id));
+    for (const target_id of this.target_ids) {
+      target_array.push(fromUuidSync(target_id));
     }
     return target_array;
   }
@@ -296,7 +296,7 @@ export class BrCommonCard {
   recover_targets_from_user() {
     this.target_ids = [];
     for (const target of game.user.targets) {
-      this.target_ids.push(target.id);
+      this.target_ids.push(target.document.uuid);
     }
   }
 


### PR DESCRIPTION
## Summary by Sourcery

Persist card target references using token UUIDs instead of token IDs and document the change in the changelog.

Bug Fixes:
- Fix target restoration by referencing tokens via UUIDs instead of canvas-specific IDs.

Documentation:
- Document the UUID-based target storage change in the changelog.