### PR TITLE
Update from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 5.0.6
+* Changed targets to be saved as uuids
+
 # Version 5.0.5
 * Ensure we have a skill before rolling item and damage before rolling damage when using auto-roll
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Version 5.0.5
+* Ensure we have a skill before rolling item and damage before rolling damage when using auto-roll
+
 # Version 5.0.4
 * Properly fixed the ownership bug with chat messages
 

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -283,8 +283,8 @@ export class BrCommonCard {
 
   get targets() {
     const target_array = [];
-    for (const target_id in this.target_ids) {
-      target_array.push(canvas.tokens.get(target_id));
+    for (const target_id of this.target_ids) {
+      target_array.push(fromUuidSync(target_id));
     }
     return target_array;
   }
@@ -296,7 +296,7 @@ export class BrCommonCard {
   recover_targets_from_user() {
     this.target_ids = [];
     for (const target of game.user.targets) {
-      this.target_ids.push(target.id);
+      this.target_ids.push(target.document.uuid);
     }
   }
 

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -333,8 +333,10 @@ async function item_click_listener(ev, target, currentTarget) {
   });
   if (action.includes("dialog")) {
     game.brsw.dialog.show_card(br_card);
-  } else if (action.includes("trait")) {
+  } else if (br_card.skill && action.includes("trait")) {
     await roll_item(br_card, "", false, action.includes("damage"));
+  } else if (br_card.damage && action.includes("damage")) {
+    await roll_dmg(br_card, "");
   }
   // Shortcut for rolling damage
   if (ev.target.classList.contains("damage-roll")) {


### PR DESCRIPTION
## Summary by Sourcery

Synchronize branch with mainline changes, including target handling and auto-roll safeguards.

Bug Fixes:
- Guard auto-rolls to require a skill before item rolls and damage before damage rolls when triggered via traits.

Enhancements:
- Store and resolve card targets using UUIDs instead of token IDs for improved robustness.

Documentation:
- Document versions 5.0.5 and 5.0.6 in the changelog, including target UUID handling and auto-roll safety checks.