### PR TITLE
Gang up improvements

### DIFF
--- a/lang/ca.json
+++ b/lang/ca.json
@@ -121,7 +121,7 @@
     "BRSW.Failure": "Fracàs",
     "BRSW.Free_reroll": "Tirada gratis",
     "BRSW.Fumble": "Pífia!",
-    "BRSW.Gangup": "Múltiples adversaris",
+    "BRSW.GangUp": "Múltiples adversaris",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "Modificador GM",
     "BRSW.GroupRoll": "Tirada de grup",

--- a/lang/de.json
+++ b/lang/de.json
@@ -121,7 +121,7 @@
     "BRSW.Failure": "Fehlschlag",
     "BRSW.Free_reroll": "Freier Wiederholungswurf",
     "BRSW.Fumble": "KRITISCHER FEHLSCHLAG!",
-    "BRSW.Gangup": "Überzahl",
+    "BRSW.GangUp": "Überzahl",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "SL Modifikator",
     "BRSW.GroupRoll": "Gruppenwurf",

--- a/lang/en.json
+++ b/lang/en.json
@@ -136,7 +136,7 @@
   "BRSW.Free_reroll": "Free reroll",
   "BRSW.FreeRunner": "Free Runner",
   "BRSW.Fumble": "CRITICAL FAILURE!",
-  "BRSW.Gangup": "Gangup",
+  "BRSW.GangUp": "Gang Up",
   "BRSW.GlobalTab": "Global",
   "BRSW.GMModifier": "GM modifier",
   "BRSW.GroupRoll": "Group roll",

--- a/lang/es.json
+++ b/lang/es.json
@@ -120,7 +120,7 @@
     "BRSW.Failure": "Fallo",
     "BRSW.Free_reroll": "Repetir gratis",
     "BRSW.Fumble": "¡PIFIA!",
-    "BRSW.Gangup": "Múltiples oponentes",
+    "BRSW.GangUp": "Múltiples oponentes",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "Modificador del master",
     "BRSW.GroupRoll": "Tirada de grupo",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -120,7 +120,7 @@
     "BRSW.Failure": "Échec",
     "BRSW.Free_reroll": "Relance gratuite",
     "BRSW.Fumble": "ÉCHEC CRITIQUE !",
-    "BRSW.Gangup": "Attaque à plusieurs",
+    "BRSW.GangUp": "Attaque à plusieurs",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "Modificateurs MJ",
     "BRSW.Guts": "Tripes",

--- a/lang/it.json
+++ b/lang/it.json
@@ -98,7 +98,7 @@
     "BRSW.Failure": "Fallimento",
     "BRSW.Free_reroll": "Ritira senza costi",
     "BRSW.Fumble": "FALLIMENTO CRITICO!",
-    "BRSW.Gangup": "Tutti Assieme",
+    "BRSW.GangUp": "Tutti Assieme",
     "BRSW.Guts": "Addome",
     "BRSW.HalfDamage": "Metà danno",
     "BRSW.HardyActivated": "Un secondo risultato di Scosso non causa Ferite",

--- a/lang/pt-BR.json
+++ b/lang/pt-BR.json
@@ -121,7 +121,7 @@
     "BRSW.Failure": "Falha",
     "BRSW.Free_reroll": "Rerrolagem gratuita",
     "BRSW.Fumble": "FALHA CRÍTICA!",
-    "BRSW.Gangup": "Agrupar",
+    "BRSW.GangUp": "Agrupar",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "Modificador do GM",
     "BRSW.GroupRoll": "Rolagens em Grupo",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -113,7 +113,7 @@
     "BRSW.Failure": "Falha",
     "BRSW.Free_reroll": "Rerrolagem gratuita",
     "BRSW.Fumble": "FALHA CRÍTICA!",
-    "BRSW.Gangup": "Agrupar",
+    "BRSW.GangUp": "Agrupar",
     "BRSW.GlobalTab": "Global",
     "BRSW.GMModifier": "Modificador do GM",
     "BRSW.GroupRoll": "Rolagens em Grupo",

--- a/lang/ru.json
+++ b/lang/ru.json
@@ -107,7 +107,7 @@
     "BRSW.Failure": "Провал",
     "BRSW.Free_reroll": "Бесплатный переброс",
     "BRSW.Fumble": "КРИТИЧЕСКИЙ ПРОВАЛ!",
-    "BRSW.Gangup": "Окружение",
+    "BRSW.GangUp": "Окружение",
     "BRSW.GlobalTab": "Глобальный",
     "BRSW.GMModifier": "модификатор GM",
     "BRSW.GroupRoll": "Бросок группы",

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -283,7 +283,9 @@ export class BrCommonCard {
     const target_array = [];
     for (const target_id of this.target_ids) {
       const tokenDoc = fromUuidSync(target_id);
-      target_array.push(tokenDoc.object);
+      if (tokenDoc) {
+        target_array.push(tokenDoc.object);
+      }
     }
     return target_array;
   }

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -282,7 +282,8 @@ export class BrCommonCard {
   get targets() {
     const target_array = [];
     for (const target_id of this.target_ids) {
-      target_array.push(fromUuidSync(target_id));
+      const tokenDoc = fromUuidSync(target_id);
+      target_array.push(tokenDoc.object);
     }
     return target_array;
   }

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -35,6 +35,7 @@ import { DamageModifier, TraitModifier } from "./modifiers.js";
 import { brAction } from "./actions.js";
 import { PPManagementDialog } from "./pp_management_dialog.js";
 import { get_current_generic_mods } from "../config/generic_pp_modifiers.js";
+import { calculateGangUp } from "./skill_card.js";
 
 const ATTRIBUTES = ["agility", "smarts", "spirit", "strength", "vigor"];
 
@@ -1405,20 +1406,25 @@ export async function roll_dmg(
         heavy_weapon: false,
         location: "torso",
     };
+
     const macros = [];
     if (expend_bennie) {
         await spend_bennie(actor);
     }
+
     // Calculate modifiers
     const options = get_roll_options(default_options, br_card);
+
     // Shotgun
     if (damage_formulas.damage === "1-3d6" && item.type === "weapon") {
         // Bet that this is a shotgun
         damage_formulas.damage = "3d6";
     }
+
     const damage_roll = { label: "---", brswroll: new BRWSRoll(), raise: raise };
     get_chat_dmg_modifiers(options, damage_roll);
     joker_modifiers(br_card, damage_roll);
+
     // Item properties tab
     if (item.system.actions.dmgMod) {
         const new_modifier = new DamageModifier(
@@ -1429,10 +1435,12 @@ export async function roll_dmg(
         await new_modifier.evaluate();
         damage_roll.brswroll.modifiers.push(new_modifier);
     }
+
     // Minimum strength
     if (item.system.minStr) {
         calc_min_str_penalty(item, actor, damage_formulas, damage_roll);
     }
+
     // Actions
     await get_damage_mods_from_actions(
         br_card,
@@ -1441,16 +1449,20 @@ export async function roll_dmg(
         macros,
         expend_bennie,
     );
+
     if (!damage_formulas.damage) {
         // Damage is empty and damage action has not been selected...
         damage_formulas.damage = get_any_damage_from_actions(br_card);
     }
+
     //Conviction
     const conviction_modifier = await check_and_roll_conviction(actor);
     if (conviction_modifier) {
         damage_roll.brswroll.modifiers.push(conviction_modifier);
     }
+
     get_global_modifiers(expend_bennie, actor, damage_roll, damage_formulas);
+
     // Roll
     if (damage_formulas.explodes) {
         damage_formulas.damage = makeExplotable(damage_formulas.damage);
@@ -1458,14 +1470,27 @@ export async function roll_dmg(
         damage_formulas.damage = damage_formulas.damage.replace("x", "");
         damage_formulas.raise = damage_formulas.raise.replace("x", "");
     }
+
     const targets = await get_dmg_targets(target_token_id, br_card);
     if (!raise) {
         damage_formulas.raise = "";
     }
+
+    // Gang Up on Damage
+    if (Utils.isMeleeAttack(item, actor, br_card.skill) && actor?.system.stats?.gangUpDamage && targets[0]) {
+        const gangUp = calculateGangUp(br_card.token, targets[0]);
+        if (gangUp.bonus > 0) {
+            damage_roll.brswroll.modifiers.push(
+                new DamageModifier(gangUp.name, gangUp.bonus)
+            );
+        }
+    }
+
     let total_modifiers = 0;
     for (const modifier of damage_roll.brswroll.modifiers) {
         total_modifiers += modifier.value;
     }
+
     let first_roll = true;
     for (const target of targets) {
         if (target || first_roll) {
@@ -1481,9 +1506,12 @@ export async function roll_dmg(
             first_roll = false; // Only roll once without targets.
         }
     }
+
     await update_message(br_card, render_data);
+
     // Run macros
     await run_macros(macros, actor, item, br_card);
+
     Hooks.call("BRSW-RollDamage", br_card, html);
 }
 

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -1479,7 +1479,7 @@ export async function roll_dmg(
     // Gang Up on Damage
     if (Utils.isMeleeAttack(item, actor, br_card.skill) && actor?.system.stats?.gangUpDamage && targets[0]) {
         const gangUp = calculateGangUp(br_card.token, targets[0]);
-        if (gangUp.bonus > 0) {
+        if (gangUp.bonus) {
             damage_roll.brswroll.modifiers.push(
                 new DamageModifier(gangUp.name, gangUp.bonus)
             );

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -2,21 +2,21 @@
 /* globals TokenDocument, Token, game, CONST, canvas, console, Ray, succ, fromUuid, ui, $ */
 
 import {
-  BRSW_CONST,
-  create_common_card,
-  get_action_from_click,
-  get_actor_from_ids,
-  roll_trait,
-  spend_bennie,
-  trait_to_string,
-  process_common_actions,
+    BRSW_CONST,
+    create_common_card,
+    get_action_from_click,
+    get_actor_from_ids,
+    roll_trait,
+    spend_bennie,
+    trait_to_string,
+    process_common_actions,
 } from "./cards_common.js";
 import { run_macros } from "./item_card.js";
 import {
-  SettingsUtils,
-  Utils,
-  addEventListenerAll,
-  measureDistance,
+    SettingsUtils,
+    Utils,
+    addEventListenerAll,
+    measureDistance,
 } from "./utils.js";
 import { BrCommonCard } from "./BrCommonCard.js";
 import { TraitModifier } from "./modifiers.js";
@@ -32,50 +32,50 @@ import { TraitModifier } from "./modifiers.js";
  * @return {Promise} A promise for the ChatMessage object
  */
 async function create_skill_card(
-  origin,
-  skill_id,
-  { actions_stored = {}, vehicle } = {},
-) {
-  let actor;
-  if (
-    origin instanceof TokenDocument ||
-    origin instanceof foundry.canvas.placeables.Token
-  ) {
-    actor = origin.actor;
-  } else {
-    actor = origin;
-  }
-  const skill = actor.items.find((item) => {
-    return item.id === skill_id;
-  });
-  const extra_name = skill.name + " " + trait_to_string(skill.system);
-  const br_message = create_common_card(
     origin,
-    {
-      header: {
-        type: game.i18n.localize("ITEM.TypeSkill"),
-        title: extra_name,
-        img: skill.img,
-      },
-      trait_id: skill.id,
-      description: skill.system.description,
-    },
-    "modules/betterrolls-swade2/templates/skill_card.hbs",
-  );
-  br_message.type = BRSW_CONST.TYPE_SKILL_CARD;
-  br_message.skill_id = skill.id;
-  if (vehicle) {
-    br_message.vehicle_actor_id = vehicle.actor?.id || vehicle.id;
+    skill_id,
+    { actions_stored = {}, vehicle } = {},
+) {
+    let actor;
     if (
-      vehicle instanceof TokenDocument ||
-      vehicle instanceof foundry.canvas.placeables.Token
+        origin instanceof TokenDocument ||
+        origin instanceof foundry.canvas.placeables.Token
     ) {
-      br_message.vehicle_token_id = vehicle.id;
+        actor = origin.actor;
+    } else {
+        actor = origin;
     }
-  }
-  await br_message.render(actions_stored);
-  await br_message.save();
-  return br_message;
+    const skill = actor.items.find((item) => {
+        return item.id === skill_id;
+    });
+    const extra_name = skill.name + " " + trait_to_string(skill.system);
+    const br_message = create_common_card(
+        origin,
+        {
+            header: {
+                type: game.i18n.localize("ITEM.TypeSkill"),
+                title: extra_name,
+                img: skill.img,
+            },
+            trait_id: skill.id,
+            description: skill.system.description,
+        },
+        "modules/betterrolls-swade2/templates/skill_card.hbs",
+    );
+    br_message.type = BRSW_CONST.TYPE_SKILL_CARD;
+    br_message.skill_id = skill.id;
+    if (vehicle) {
+        br_message.vehicle_actor_id = vehicle.actor?.id || vehicle.id;
+        if (
+            vehicle instanceof TokenDocument ||
+            vehicle instanceof foundry.canvas.placeables.Token
+        ) {
+            br_message.vehicle_token_id = vehicle.id;
+        }
+    }
+    await br_message.render(actions_stored);
+    await br_message.save();
+    return br_message;
 }
 
 /**
@@ -91,24 +91,24 @@ async function create_skill_card(
  * @return {Promise} a promise fot the ChatMessage object
  */
 function create_skill_card_from_id(
-  token_id,
-  actor_id,
-  skill_id,
-  { actions_stored = {} } = {},
+    token_id,
+    actor_id,
+    skill_id,
+    { actions_stored = {} } = {},
 ) {
-  const actor = get_actor_from_ids(token_id, actor_id);
-  return create_skill_card(actor, skill_id, {
-    actions_stored: actions_stored,
-  });
+    const actor = get_actor_from_ids(token_id, actor_id);
+    return create_skill_card(actor, skill_id, {
+        actions_stored: actions_stored,
+    });
 }
 
 /**
  * Hooks the public functions to a global object
  */
 export function skill_card_hooks() {
-  game.brsw.create_skill_card = create_skill_card;
-  game.brsw.create_skill_card_from_id = create_skill_card_from_id;
-  game.brsw.roll_skill = roll_skill;
+    game.brsw.create_skill_card = create_skill_card;
+    game.brsw.create_skill_card_from_id = create_skill_card_from_id;
+    game.brsw.roll_skill = roll_skill;
 }
 
 /**
@@ -117,24 +117,24 @@ export function skill_card_hooks() {
  * @param {SwadeActor, Token} target token or actor from the char sheet
  */
 async function skill_click_listener(ev, target) {
-  const action = get_action_from_click(ev);
-  if (action === "system") {
-    return;
-  }
-  ev.stopImmediatePropagation();
-  ev.preventDefault();
-  ev.stopPropagation();
-  // First term for PC, second one for NPCs
-  const skill_id =
-    ev.currentTarget.parentElement.parentElement.dataset.itemId ||
-    ev.currentTarget.parentElement.dataset.itemId;
-  // Show card
-  const br_card = await create_skill_card(target, skill_id);
-  if (action.includes("dialog")) {
-    game.brsw.dialog.show_card(br_card);
-  } else if (action.includes("trait")) {
-    await roll_skill(br_card, false);
-  }
+    const action = get_action_from_click(ev);
+    if (action === "system") {
+        return;
+    }
+    ev.stopImmediatePropagation();
+    ev.preventDefault();
+    ev.stopPropagation();
+    // First term for PC, second one for NPCs
+    const skill_id =
+        ev.currentTarget.parentElement.parentElement.dataset.itemId ||
+        ev.currentTarget.parentElement.dataset.itemId;
+    // Show card
+    const br_card = await create_skill_card(target, skill_id);
+    if (action.includes("dialog")) {
+        game.brsw.dialog.show_card(br_card);
+    } else if (action.includes("trait")) {
+        await roll_skill(br_card, false);
+    }
 }
 
 /**
@@ -143,16 +143,16 @@ async function skill_click_listener(ev, target) {
  * @param html Html code
  */
 export function activate_skill_listeners(app, html) {
-  const target = app.token || app.actor || app.object;
-  addEventListenerAll(
-    html,
-    ".skill-label a, .skill.item>a, .skill-name, .skill-die",
-    "click",
-    async (ev) => {
-      await skill_click_listener(ev, target);
-    },
-    true,
-  );
+    const target = app.token || app.actor || app.object;
+    addEventListenerAll(
+        html,
+        ".skill-label a, .skill.item>a, .skill-name, .skill-die",
+        "click",
+        async (ev) => {
+            await skill_click_listener(ev, target);
+        },
+        true,
+    );
 }
 
 /**
@@ -161,18 +161,18 @@ export function activate_skill_listeners(app, html) {
  * @param html Html produced
  */
 export function activate_skill_card_listeners(br_card, html) {
-  addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
-    ev.stopPropagation();
-    await roll_skill(
-      br_card,
-      ev.currentTarget.classList.contains("roll-bennie-button"),
-    );
-  });
-  html.querySelector(".brsw-header-img").addEventListener("click", (_) => {
-    const { render_data, actor } = br_card;
-    const item = actor.items.get(render_data.trait_id);
-    item.sheet.render(true);
-  });
+    addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
+        ev.stopPropagation();
+        await roll_skill(
+            br_card,
+            ev.currentTarget.classList.contains("roll-bennie-button"),
+        );
+    });
+    html.querySelector(".brsw-header-img").addEventListener("click", (_) => {
+        const { render_data, actor } = br_card;
+        const item = actor.items.get(render_data.trait_id);
+        item.sheet.render(true);
+    });
 }
 
 /**
@@ -182,25 +182,25 @@ export function activate_skill_card_listeners(br_card, html) {
  * @param {boolean} expend_bennie True if we want to spend a bennie
  */
 export async function roll_skill(br_card, expend_bennie) {
-  const extra_data = { modifiers: [] };
-  const macros = [];
-  // Actions
-  for (const action of br_card.get_selected_actions()) {
-    process_common_actions(action.code, extra_data, macros, br_card.actor);
-  }
-  if (br_card.trait_roll.is_rolled) {
-    br_card.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
-  }
-  if (expend_bennie) {
-    await spend_bennie(br_card.actor);
-  }
-  await roll_trait(
-    br_card,
-    br_card.skill.system,
-    game.i18n.localize("BRSW.SkillDie"),
-    extra_data,
-  );
-  await run_macros(macros, br_card.actor, null, br_card);
+    const extra_data = { modifiers: [] };
+    const macros = [];
+    // Actions
+    for (const action of br_card.get_selected_actions()) {
+        process_common_actions(action.code, extra_data, macros, br_card.actor);
+    }
+    if (br_card.trait_roll.is_rolled) {
+        br_card.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
+    }
+    if (expend_bennie) {
+        await spend_bennie(br_card.actor);
+    }
+    await roll_trait(
+        br_card,
+        br_card.skill.system,
+        game.i18n.localize("BRSW.SkillDie"),
+        extra_data,
+    );
+    await run_macros(macros, br_card.actor, null, br_card);
 }
 
 /**
@@ -214,65 +214,65 @@ export async function roll_skill(br_card, expend_bennie) {
  * @returns {number}
  */
 function calculate_generic_distance_modifier(
-  item,
-  distance,
-  origin_token,
-  target_token,
-  skill,
-  tn,
-  extra_data,
+    item,
+    distance,
+    origin_token,
+    target_token,
+    skill,
+    tn,
+    extra_data,
 ) {
-  const range = item.system.range.split("/");
-  if (origin_token.document.elevation !== target_token.document.elevation) {
-    const h_diff = Math.abs(
-      origin_token.document.elevation - target_token.document.elevation,
-    );
-    distance = Math.sqrt(Math.pow(h_diff, 2) + Math.pow(distance, 2));
-  }
-  let distance_penalty = 0;
-  let rangeEffects;
-  if (!Utils.isShootingSkill(skill)) {
-    // Throwing skill them
-    rangeEffects = origin_token.actor.appliedEffects.find((e) =>
-      e.changes.find((ch) => ch.key === "brsw.thrown-range-modifier"),
-    );
-    if (rangeEffects) {
-      if (rangeEffects.disabled) {
-        rangeEffects = null;
-      } else {
-        rangeEffects = rangeEffects.changes.find(
-          (ch) => ch.key === "brsw.thrown-range-modifier",
-        ).value;
-      }
+    const range = item.system.range.split("/");
+    if (origin_token.document.elevation !== target_token.document.elevation) {
+        const h_diff = Math.abs(
+            origin_token.document.elevation - target_token.document.elevation,
+        );
+        distance = Math.sqrt(Math.pow(h_diff, 2) + Math.pow(distance, 2));
     }
-  }
-  const extreme_range = 0;
-  for (let i = 0; i < 3 && i < range.length; i++) {
-    let range_int = parseInt(range[i]);
-    if (rangeEffects) {
-      range_int += rangeEffects * (i + 1);
+    let distance_penalty = 0;
+    let rangeEffects;
+    if (!Utils.isShootingSkill(skill)) {
+        // Throwing skill them
+        rangeEffects = origin_token.actor.appliedEffects.find((e) =>
+            e.changes.find((ch) => ch.key === "brsw.thrown-range-modifier"),
+        );
+        if (rangeEffects) {
+            if (rangeEffects.disabled) {
+                rangeEffects = null;
+            } else {
+                rangeEffects = rangeEffects.changes.find(
+                    (ch) => ch.key === "brsw.thrown-range-modifier",
+                ).value;
+            }
+        }
     }
-    if (range_int && range_int < distance) {
-      distance_penalty = i < 2 ? (i + 1) * 2 : 8;
+    const extreme_range = 0;
+    for (let i = 0; i < 3 && i < range.length; i++) {
+        let range_int = parseInt(range[i]);
+        if (rangeEffects) {
+            range_int += rangeEffects * (i + 1);
+        }
+        if (range_int && range_int < distance) {
+            distance_penalty = i < 2 ? (i + 1) * 2 : 8;
+        }
     }
-  }
-  if (extreme_range && distance > extreme_range * 4) {
-    tn.modifiers.push(
-      new TraitModifier(game.i18n.localize("BRSW.OverExtremeRange"), -999),
-    );
-  }
-  if (distance_penalty) {
-    tn.modifiers.push(
-      new TraitModifier(
-        game.i18n.localize("BRSW.Range") + " " + distance.toFixed(2),
-        -distance_penalty,
-      ),
-    );
-    //Range penalties can be ignored by aiming so add it to the total
-    extra_data.total_aiming_ignorable_penalties =
-      extra_data.total_aiming_ignorable_penalties ?? 0;
-    extra_data.total_aiming_ignorable_penalties += distance_penalty;
-  }
+    if (extreme_range && distance > extreme_range * 4) {
+        tn.modifiers.push(
+            new TraitModifier(game.i18n.localize("BRSW.OverExtremeRange"), -999),
+        );
+    }
+    if (distance_penalty) {
+        tn.modifiers.push(
+            new TraitModifier(
+                game.i18n.localize("BRSW.Range") + " " + distance.toFixed(2),
+                -distance_penalty,
+            ),
+        );
+        //Range penalties can be ignored by aiming so add it to the total
+        extra_data.total_aiming_ignorable_penalties =
+            extra_data.total_aiming_ignorable_penalties ?? 0;
+        extra_data.total_aiming_ignorable_penalties += distance_penalty;
+    }
 }
 
 /**
@@ -285,45 +285,45 @@ function calculate_generic_distance_modifier(
  * @return {boolean} True if parry should be used as the tn (tokens are adjacent)
  */
 export function calculate_distance(
-  origin_token,
-  target_token,
-  item,
-  tn,
-  skill,
-  extra_data,
+    origin_token,
+    target_token,
+    item,
+    tn,
+    skill,
+    extra_data,
 ) {
-  if (item.system.isVehicular && origin_token.actor.type !== "vehicle") {
-    return false;
-  }
-  const grid_unit = canvas.grid.distance;
-  let use_parry_as_tn = false;
-  let distance = measureDistance(origin_token, target_token);
-  if (
-    distance / grid_unit < SettingsUtils.getWorldSetting("meleeDistance") + 1 &&
-    item
-  ) {
-    use_parry_as_tn = item.type !== "power";
-  } else if (item) {
-    if (grid_unit % 5 === 0) {
-      distance /= 5;
+    if (item.system.isVehicular && origin_token.actor.type !== "vehicle") {
+        return false;
     }
-    if (item.type === "power") {
-      if (distance > item.system.range) {
-        ui.notifications.error(game.i18n.localize("BRSW.SpellOverRange"));
-      }
-    } else {
-      calculate_generic_distance_modifier(
-        item,
-        distance,
-        origin_token,
-        target_token,
-        skill,
-        tn,
-        extra_data,
-      );
+    const grid_unit = canvas.grid.distance;
+    let use_parry_as_tn = false;
+    let distance = measureDistance(origin_token, target_token);
+    if (
+        distance / grid_unit < SettingsUtils.getWorldSetting("meleeDistance") + 1 &&
+        item
+    ) {
+        use_parry_as_tn = item.type !== "power";
+    } else if (item) {
+        if (grid_unit % 5 === 0) {
+            distance /= 5;
+        }
+        if (item.type === "power") {
+            if (distance > item.system.range) {
+                ui.notifications.error(game.i18n.localize("BRSW.SpellOverRange"));
+            }
+        } else {
+            calculate_generic_distance_modifier(
+                item,
+                distance,
+                origin_token,
+                target_token,
+                skill,
+                tn,
+                extra_data,
+            );
+        }
     }
-  }
-  return use_parry_as_tn;
+    return use_parry_as_tn;
 }
 
 /**
@@ -332,22 +332,22 @@ export function calculate_distance(
  * @param target_token
  */
 async function get_vehicle_tn(tn, target_token) {
-  tn.reason = `Veh - ${target_token.name}`;
-  //lookup the vehicle operator and get their maneuveringSkill
-  let operator_skill;
-  const target_operator_id = target_token.actor.system.driver.id;
-  const target_operator = await fromUuid(target_operator_id);
-  const operatorItems = target_operator ? target_operator.items : [];
-  const maneuveringSkill = target_token.actor.system.driver.skill;
-  for (const value of operatorItems) {
-    if (value.name === maneuveringSkill) {
-      operator_skill = value.system.die.sides;
+    tn.reason = `Veh - ${target_token.name}`;
+    //lookup the vehicle operator and get their maneuveringSkill
+    let operator_skill;
+    const target_operator_id = target_token.actor.system.driver.id;
+    const target_operator = await fromUuid(target_operator_id);
+    const operatorItems = target_operator ? target_operator.items : [];
+    const maneuveringSkill = target_token.actor.system.driver.skill;
+    for (const value of operatorItems) {
+        if (value.name === maneuveringSkill) {
+            operator_skill = value.system.die.sides;
+        }
     }
-  }
-  if (operator_skill === null) {
-    operator_skill = 0;
-  }
-  tn.value = operator_skill / 2 + 2 + target_token.actor.system.handling;
+    if (operator_skill === null) {
+        operator_skill = 0;
+    }
+    tn.value = operator_skill / 2 + 2 + target_token.actor.system.handling;
 }
 
 /**
@@ -359,75 +359,75 @@ async function get_vehicle_tn(tn, target_token) {
  * @param {Item} item
  */
 export async function get_tn_from_token(
-  skill,
-  target_token,
-  origin_token,
-  origin_actor,
-  item,
-  extra_data,
+    skill,
+    target_token,
+    origin_token,
+    origin_actor,
+    item,
+    extra_data,
 ) {
-  const tn = {
-    reason: game.i18n.localize("BRSW.Default"),
-    value: 4,
-    modifiers: [],
-  };
-  const is_fighting = Utils.isFightingSkill(skill);
-  let use_parry_as_tn = is_fighting;
-  if (origin_token) {
-    if (is_fighting) {
-      const gangup = calculate_gangUp(origin_token, target_token);
-      if (gangup.bonus) {
-        tn.modifiers.push(new TraitModifier(gangup.name, gangup.bonus));
-      }
-    } else if (item && item.system.range) {
-      use_parry_as_tn = calculate_distance(
-        origin_token,
-        target_token,
-        item,
-        tn,
-        skill,
-        extra_data,
-      );
+    const tn = {
+        reason: game.i18n.localize("BRSW.Default"),
+        value: 4,
+        modifiers: [],
+    };
+    const is_fighting = Utils.isFightingSkill(skill);
+    let use_parry_as_tn = is_fighting;
+    if (origin_token) {
+        if (is_fighting) {
+            const gangup = calculateGangUp(origin_token, target_token);
+            if (gangup.bonus) {
+                tn.modifiers.push(new TraitModifier(gangup.name, gangup.bonus));
+            }
+        } else if (item && item.system.range) {
+            use_parry_as_tn = calculate_distance(
+                origin_token,
+                target_token,
+                item,
+                tn,
+                skill,
+                extra_data,
+            );
+        }
     }
-  }
-  if (use_parry_as_tn) {
-    if (target_token.actor.type !== "vehicle") {
-      tn.reason = `${game.i18n.localize("SWADE.Parry")} - ${target_token.name}`;
-      tn.value = parseInt(target_token.actor.system.stats.parry.value);
-    } else {
-      await get_vehicle_tn(tn, target_token);
+    if (use_parry_as_tn) {
+        if (target_token.actor.type !== "vehicle") {
+            tn.reason = `${game.i18n.localize("SWADE.Parry")} - ${target_token.name}`;
+            tn.value = parseInt(target_token.actor.system.stats.parry.value);
+        } else {
+            await get_vehicle_tn(tn, target_token);
+        }
     }
-  }
-  // Size modifiers
-  if (shouldUseScale(origin_actor, target_token, item, skill)) {
-    getScaleModifier(origin_actor, target_token.actor, item, tn, extra_data);
-  }
-  if (
-    target_token.actor.system.status.isVulnerable ||
-    target_token.actor.system.status.isStunned
-  ) {
-    tn.modifiers.push(
-      new TraitModifier(
-        `${target_token.name}: ${game.i18n.localize("SWADE.Vuln")}`,
-        2,
-      ),
-    );
-  }
-  return tn;
+    // Size modifiers
+    if (shouldUseScale(origin_actor, target_token, item, skill)) {
+        getScaleModifier(origin_actor, target_token.actor, item, tn, extra_data);
+    }
+    if (
+        target_token.actor.system.status.isVulnerable ||
+        target_token.actor.system.status.isStunned
+    ) {
+        tn.modifiers.push(
+            new TraitModifier(
+                `${target_token.name}: ${game.i18n.localize("SWADE.Vuln")}`,
+                2,
+            ),
+        );
+    }
+    return tn;
 }
 
 function shouldUseScale(origin_actor, target_token, item, skill) {
-  if (!origin_actor || !target_token) return false;
-  if (item?.system?.isVehicular || origin_actor.type === "vehicle") return false;
+    if (!origin_actor || !target_token) return false;
+    if (item?.system?.isVehicular || origin_actor.type === "vehicle") return false;
 
-  if (!item) {
-    return Utils.isFightingSkill(skill) || Utils.isShootingSkill(skill) || Utils.isThrowingSkill(skill);
-  }
+    if (!item) {
+        return Utils.isFightingSkill(skill) || Utils.isShootingSkill(skill) || Utils.isThrowingSkill(skill);
+    }
 
-  if (item.type === "weapon") return true;
-  if (item.type === "power" && item.name.toLowerCase().includes("bolt")) return true;
+    if (item.type === "weapon") return true;
+    if (item.type === "power" && item.name.toLowerCase().includes("bolt")) return true;
 
-  return false;
+    return false;
 }
 
 /**
@@ -436,60 +436,60 @@ function shouldUseScale(origin_actor, target_token, item, skill) {
 
 function getScaleModifier(origin_actor, target_actor, item, tn, extra_data) {
 
-  const originScaleMod = sizeToScale(origin_actor?.system?.stats?.size || 1);
-  const targetScaleMod = sizeToScale(
-    target_actor?.system?.size || // Vehicles
-      target_actor?.system?.stats?.size ||
-      1,
-  ); // actor or default
+    const originScaleMod = sizeToScale(origin_actor?.system?.stats?.size || 1);
+    const targetScaleMod = sizeToScale(
+        target_actor?.system?.size || // Vehicles
+        target_actor?.system?.stats?.size ||
+        1,
+    ); // actor or default
 
-  if (originScaleMod === targetScaleMod) {
-    //Actors are the same scale so there is no mod
-    return;
-  }
-
-  const scaleMod = targetScaleMod - originScaleMod;
-  if (scaleMod > 0 && item.type === "power" && item.name.toLowerCase().includes("bolt")) {
-    //Bolt is only affected by scale penalties, not bonuses
-    return;
-  }
-
-  tn.modifiers.push(
-    new TraitModifier(game.i18n.localize("BRSW.Scale"), scaleMod),
-  );
-
-  //Scale does not affect arcane activation
-  extra_data.arcaneActivationOffset += scaleMod;
-
-  // If the scale mod is negative, check if the attacking actor has the swat ability
-  if (scaleMod < 0 && origin_actor) {
-    let unignoredPenalty = scaleMod * -1;
-
-    const swat = origin_actor.items.find((item) => {
-      return (
-        item.type === "ability" &&
-        item.name
-          .toLowerCase()
-          .includes(game.i18n.localize("BRSW.Swat").toLowerCase())
-      );
-    });
-
-    if (swat) {
-      // The swat ability ignores up to 4 points of scale penalties
-      const swatMod = scaleMod < -4 ? 4 : scaleMod * -1;
-      unignoredPenalty -= swatMod;
-      tn.modifiers.push(
-        new TraitModifier(game.i18n.localize("BRSW.Swat"), swatMod),
-      );
+    if (originScaleMod === targetScaleMod) {
+        //Actors are the same scale so there is no mod
+        return;
     }
 
-    if (unignoredPenalty > 0) {
-      //Scale penalties can be ignored by aiming so add it to the total
-      extra_data.total_aiming_ignorable_penalties =
-        extra_data.total_aiming_ignorable_penalties ?? 0;
-      extra_data.total_aiming_ignorable_penalties += unignoredPenalty;
+    const scaleMod = targetScaleMod - originScaleMod;
+    if (scaleMod > 0 && item.type === "power" && item.name.toLowerCase().includes("bolt")) {
+        //Bolt is only affected by scale penalties, not bonuses
+        return;
     }
-  }
+
+    tn.modifiers.push(
+        new TraitModifier(game.i18n.localize("BRSW.Scale"), scaleMod),
+    );
+
+    //Scale does not affect arcane activation
+    extra_data.arcaneActivationOffset += scaleMod;
+
+    // If the scale mod is negative, check if the attacking actor has the swat ability
+    if (scaleMod < 0 && origin_actor) {
+        let unignoredPenalty = scaleMod * -1;
+
+        const swat = origin_actor.items.find((item) => {
+            return (
+                item.type === "ability" &&
+                item.name
+                    .toLowerCase()
+                    .includes(game.i18n.localize("BRSW.Swat").toLowerCase())
+            );
+        });
+
+        if (swat) {
+            // The swat ability ignores up to 4 points of scale penalties
+            const swatMod = scaleMod < -4 ? 4 : scaleMod * -1;
+            unignoredPenalty -= swatMod;
+            tn.modifiers.push(
+                new TraitModifier(game.i18n.localize("BRSW.Swat"), swatMod),
+            );
+        }
+
+        if (unignoredPenalty > 0) {
+            //Scale penalties can be ignored by aiming so add it to the total
+            extra_data.total_aiming_ignorable_penalties =
+                extra_data.total_aiming_ignorable_penalties ?? 0;
+            extra_data.total_aiming_ignorable_penalties += unignoredPenalty;
+        }
+    }
 }
 
 /**
@@ -499,153 +499,135 @@ function getScaleModifier(origin_actor, target_actor, item, tn, extra_data) {
  **/
 
 function sizeToScale(size) {
-  //p179 swade core
-  if (size === -4) {
-    return -6;
-  } else if (size === -3) {
-    return -4;
-  } else if (size === -2) {
-    return -2;
-  } else if (size >= -1 && size <= 3) {
-    return 0;
-  } else if (size >= 4 && size <= 7) {
-    return 2;
-  } else if (size >= 8 && size <= 11) {
-    return 4;
-  } else if (size >= 12) {
-    return 6;
-  }
-  return 0; // Failsafe.
+    //p179 swade core
+    if (size === -4) {
+        return -6;
+    } else if (size === -3) {
+        return -4;
+    } else if (size === -2) {
+        return -2;
+    } else if (size >= -1 && size <= 3) {
+        return 0;
+    } else if (size >= 4 && size <= 7) {
+        return 2;
+    } else if (size >= 8 && size <= 11) {
+        return 4;
+    } else if (size >= 12) {
+        return 6;
+    }
+    return 0; // Failsafe.
 }
 
 /**
  *  Calculates gangup modifier, by Bruno Calado
- * @param {Token }attacker
- * @param {Token }target
+ * @param {Token|TokenDocument} attacker
+ * @param {Token|TokenDocument} target
  * @return {number} modifier
  * pg 101 swade core
  * - Each additional adjacent foe (who is not Stunned)
  * - adds +1 to all the attackers’ Fighting rolls, up to a maximum of +4.
  * - Each ally adjacent to the defender cancels out one point of Gang Up bonus from an attacker adjacent to both.
  */
-function calculate_gangUp(attacker, target) {
-  if (SettingsUtils.getWorldSetting("disable-gang-up")) {
-    return { name: "NoGangup", bonus: 0 };
-  }
-  let gangup_name = game.i18n.localize("BRSW.Gangup");
-  if (!attacker || !target) {
-    console.warn(
-      "BetterRolls 2: Trying to calculate gangup with no token",
-      attacker,
-      target,
-    );
-    return 0;
-  }
-  if (attacker.document.disposition === target.document.disposition) {
-    return 0;
-  }
-  let enemies = 0;
-  let allies = 0;
-  if (
-    attacker.document.disposition === 1 ||
-    attacker.document.disposition === -1
-  ) {
-    const item_range = SettingsUtils.getWorldSetting("meleeDistance") + 1;
-    // disposition -1 means NPC (hostile) is attacking PCs (friendly)
-    // disposition 1 means PC (friendly) is attacking NPC (hostile)
-    const allies_within_range_of_target = canvas.tokens.placeables.filter(
-      (t) =>
-        t.id !== attacker.id &&
-        t.document.disposition === attacker.document.disposition &&
-        t.visible &&
-        withinRange(target, t, item_range) &&
-        combatant_gives_gangup(t.combatant, t.actor),
-    );
-    const enemies_within_range_of_target = canvas.tokens.placeables.filter(
-      (t) =>
-        t.id !== target.id &&
-        t.document.disposition === attacker.document.disposition * -1 &&
-        withinRange(target, t, item_range) &&
-        combatant_gives_gangup(t.combatant, t.actor),
-    );
-    //alliedWithinRangeOfTargetAndAttacker intersection with attacker and target
-    const enemies_within_range_both_attacker_target =
-      enemies_within_range_of_target.filter(
-        (t) =>
-          t.document.disposition === attacker.document.disposition * -1 &&
-          withinRange(attacker, t, item_range) &&
-          combatant_gives_gangup(t.combatant, t.actor),
-      );
-    const formation_fighter_name = game.i18n
-      .localize("BRSW.EdgeName.FormationFighter")
-      .toLowerCase();
-    const allies_with_formation_fighter = allies_within_range_of_target.filter(
-      (t) =>
-        // no need to check for all the things that allies_within_range_of_target
-        // is already filtered for
-        t.actor?.items.find((item) => {
-          return item.name.toLowerCase().includes(formation_fighter_name);
-        }),
-    );
-    if (allies_with_formation_fighter.length > 0) {
-      gangup_name += `, ${game.i18n.localize("BRSW.EdgeName.FormationFighter")}`;
+export function calculateGangUp(attacker, target) {
+    if (SettingsUtils.getWorldSetting("disable-gang-up")) {
+        return { name: "NoGangup", bonus: 0 };
     }
-    enemies =
-      allies_within_range_of_target.length +
-      allies_with_formation_fighter.length;
-    if (
-      enemies > 0 &&
-      attacker.actor?.items.find((item) => {
-        return item.name.toLowerCase().includes(formation_fighter_name);
-      })
-    ) {
-      enemies += 1;
+
+    if (!attacker || !target) {
+        console.warn(
+            "BetterRolls 2: Trying to calculate gangup with no token",
+            attacker,
+            target,
+        );
+        return 0;
     }
-    // allies with formation fighter are counted twice
-    allies = enemies_within_range_both_attacker_target.length;
-  }
-  const reduction = gang_up_reduction(target.actor);
-  if (reduction) {
-    gangup_name += `, ${game.i18n.localize("BRSW.ReducedBy")}: ${reduction}`;
-  }
-  const addition = gang_up_addition(attacker.actor);
-  if (addition) {
-    gangup_name += `, ${game.i18n.localize("BRSW.IncreasedBy")}: ${addition}`;
-  }
-  let modifier = Math.max(0, enemies - allies - reduction + addition);
-  const improved_block_name = game.i18n
-    .localize("BRSW.EdgeName.ImprovedBlock")
-    .toLowerCase();
-  const block_name = game.i18n.localize("BRSW.EdgeName.Block").toLowerCase();
-  let findBlock = true;
-  const blockEffects = target.actor.appliedEffects.filter((e) =>
-    e.name.toLowerCase().includes(block_name),
-  );
-  for (const effect of blockEffects) {
-    for (const change of effect.changes) {
-      if (change.key === "brsw-ac.gangup-reduction") {
-        findBlock = false;
-      }
+
+    if (attacker.document.disposition === target.document.disposition) {
+        return 0;
     }
-  }
-  if (target.actor && findBlock) {
-    if (
-      target.actor.items.find((item) => {
-        return item.name.toLowerCase().includes(improved_block_name);
-      })
-    ) {
-      gangup_name += ', ${game.i18n.localize("BRSW.EdgeName.ImprovedBlock")}';
-      modifier = Math.max(0, modifier - 2);
-    } else if (
-      target.actor.items.find((item) => {
-        return item.name.toLowerCase().includes(block_name);
-      })
-    ) {
-      modifier = Math.max(0, modifier - 1);
-      gangup_name += ', ${game.i18n.localize("BRSW.EdgeName.Block")}';
+
+    let attackerAllies = 0;
+    let targetAllies = 0;
+    if (attacker.document.disposition === 1 || attacker.document.disposition === -1) {
+        const item_range = SettingsUtils.getWorldSetting("meleeDistance") + 1;
+
+        // disposition -1 means NPC (hostile) is attacking PCs (friendly)
+        // disposition 1 means PC (friendly) is attacking NPC (hostile)
+        const attackerAlliesWithinRangeOfTarget = canvas.tokens.placeables.filter(
+            (t) =>
+                t.id !== attacker.id &&
+                t.document.disposition === attacker.document.disposition &&
+                t.visible &&
+                withinRange(target, t, item_range) &&
+                combatant_gives_gangup(t.combatant, t.actor),
+        );
+
+        const targetAlliesWithinRangeOfTarget = canvas.tokens.placeables.filter(
+            (t) =>
+                t.id !== target.id &&
+                t.document.disposition === attacker.document.disposition * -1 &&
+                withinRange(target, t, item_range) &&
+                combatant_gives_gangup(t.combatant, t.actor),
+        );
+
+        //alliedWithinRangeOfTargetAndAttacker intersection with attacker and target
+        const targetAlliesWithinRangeOfBoth = targetAlliesWithinRangeOfTarget.filter(
+            (t) =>
+                t.document.disposition === attacker.document.disposition * -1 &&
+                withinRange(attacker, t, item_range) &&
+                combatant_gives_gangup(t.combatant, t.actor),
+        );
+
+        targetAllies = targetAlliesWithinRangeOfBoth.length;
+
+        const formationFighterName = game.i18n.localize("BRSW.EdgeName.FormationFighter").toLowerCase();
+
+        const attackerHasFormationFighter = attacker.actor?.items.find((item) => {
+            return item.name.toLowerCase().includes(formationFighterName);
+        });
+
+        const attackerAlliesWithFormationFighter = attackerAlliesWithinRangeOfTarget.filter(
+            (t) =>
+                // no need to check for all the things that attackerAlliesWithinRangeOfTarget
+                // is already filtered for
+                t.actor?.items.find((item) => {
+                    return item.name.toLowerCase().includes(formationFighterName);
+                }),
+        );
+
+        attackerAllies = attackerAlliesWithinRangeOfTarget.length + attackerAlliesWithFormationFighter.length;
+        if (attackerAllies > 0 && attackerHasFormationFighter) {
+            attackerAllies += 1;
+        }
     }
-  }
-  return { name: gangup_name, bonus: Math.min(4, modifier) };
+
+    const reduction = gang_up_reduction(target.actor);
+    const addition = gang_up_addition(attacker.actor);
+
+    let modifier = Math.max(0, attackerAllies - targetAllies - reduction + addition);
+
+    const blockName = game.i18n.localize("BRSW.EdgeName.Block").toLowerCase();
+    const impBlockName = game.i18n.localize("BRSW.EdgeName.ImprovedBlock").toLowerCase();
+
+    if (target.actor) {
+        const blockEffects = target.actor.appliedEffects.filter((e) =>
+            e.name.toLowerCase().includes(blockName) &&
+            !e.changes.find(c => c.key === "brsw-ac.gangup-reduction")
+        );
+
+        const impBlockEffects = target.actor.appliedEffects.filter((e) =>
+            e.name.toLowerCase().includes(impBlockName) &&
+            !e.changes.find(c => c.key === "brsw-ac.gangup-reduction")
+        );
+
+        if (impBlockEffects.length) {
+            modifier = Math.max(0, modifier - 2);
+        } else if (blockEffects.length) {
+            modifier = Math.max(0, modifier - 1);
+        }
+    }
+
+    return { name: game.i18n.localize("BRSW.GangUp"), bonus: Math.min(4, modifier) };
 }
 
 /**
@@ -653,17 +635,17 @@ function calculate_gangUp(attacker, target) {
  * @param {Actor} target
  */
 function gang_up_reduction(target) {
-  let reduction = 0;
-  for (const effect of target.appliedEffects) {
-    if (!effect.disabled) {
-      for (const change of effect.changes) {
-        if (change.key === "brsw-ac.gangup-reduction") {
-          reduction += parseInt(change.value) || 0;
+    let reduction = 0;
+    for (const effect of target.appliedEffects) {
+        if (!effect.disabled) {
+            for (const change of effect.changes) {
+                if (change.key === "brsw-ac.gangup-reduction") {
+                    reduction += parseInt(change.value) || 0;
+                }
+            }
         }
-      }
     }
-  }
-  return reduction;
+    return reduction;
 }
 
 /**
@@ -671,28 +653,28 @@ function gang_up_reduction(target) {
  * @param {Actor} attacker
  */
 function gang_up_addition(attacker) {
-  let addition = 0;
-  for (const effect of attacker.appliedEffects) {
-    if (!effect.disabled) {
-      for (const change of effect.changes) {
-        if (change.key === "brsw-ac.gangup-addition") {
-          addition += parseInt(change.value) ? change.value : 0;
+    let addition = 0;
+    for (const effect of attacker.appliedEffects) {
+        if (!effect.disabled) {
+            for (const change of effect.changes) {
+                if (change.key === "brsw-ac.gangup-addition") {
+                    addition += parseInt(change.value) ? change.value : 0;
+                }
+            }
         }
-      }
     }
-  }
-  return addition;
+    return addition;
 }
 
 // function from Kekilla
 function withinRange(origin, target, range) {
-  if (Math.abs(origin.document.elevation - target.document.elevation) >= 1) {
-    return false;
-  }
-  const grid_unit = canvas.grid.distance;
-  let distance = measureDistance(origin, target);
-  distance /= grid_unit;
-  return range > distance;
+    if (Math.abs(origin.document.elevation - target.document.elevation) >= 1) {
+        return false;
+    }
+    const grid_unit = canvas.grid.distance;
+    let distance = measureDistance(origin, target);
+    distance /= grid_unit;
+    return range > distance;
 }
 
 /**
@@ -701,10 +683,10 @@ function withinRange(origin, target, range) {
  * @param {SwadeActor} actor
  */
 function combatant_gives_gangup(combatant, actor) {
-  let unable_to_contribute =
-    actor.system.status.isStunned || actor.statuses.has("incapacitated");
-  if (combatant) {
-    unable_to_contribute = unable_to_contribute || combatant.defeated;
-  }
-  return !unable_to_contribute;
+    let unable_to_contribute =
+        actor.system.status.isStunned || actor.statuses.has("incapacitated");
+    if (combatant) {
+        unable_to_contribute = unable_to_contribute || combatant.defeated;
+    }
+    return !unable_to_contribute;
 }

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -449,7 +449,7 @@ function getScaleModifier(origin_actor, target_actor, item, tn, extra_data) {
     }
 
     const scaleMod = targetScaleMod - originScaleMod;
-    if (scaleMod > 0 && item.type === "power" && item.name.toLowerCase().includes("bolt")) {
+    if (scaleMod > 0 && Utils.isBolt(item)) {
         //Bolt is only affected by scale penalties, not bonuses
         return;
     }
@@ -458,8 +458,10 @@ function getScaleModifier(origin_actor, target_actor, item, tn, extra_data) {
         new TraitModifier(game.i18n.localize("BRSW.Scale"), scaleMod),
     );
 
-    //Scale does not affect arcane activation
-    extra_data.arcaneActivationOffset += scaleMod;
+    if (extra_data.arcaneActivationOffset !== undefined) {
+        //Scale does not affect arcane activation
+        extra_data.arcaneActivationOffset += scaleMod;
+    }
 
     // If the scale mod is negative, check if the attacking actor has the swat ability
     if (scaleMod < 0 && origin_actor) {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -334,18 +334,15 @@ export function calculate_distance(
 async function get_vehicle_tn(tn, target_token) {
     tn.reason = `Veh - ${target_token.name}`;
     //lookup the vehicle operator and get their maneuveringSkill
-    let operator_skill;
+    let operator_skill = 0;
     const target_operator_id = target_token.actor.system.driver.id;
     const target_operator = await fromUuid(target_operator_id);
     const operatorItems = target_operator ? target_operator.items : [];
     const maneuveringSkill = target_token.actor.system.driver.skill;
     for (const value of operatorItems) {
         if (value.name === maneuveringSkill) {
-            operator_skill = value.system.die.sides;
+            operator_skill = value.system.die.sides || 0;
         }
-    }
-    if (operator_skill === null) {
-        operator_skill = 0;
     }
     tn.value = operator_skill / 2 + 2 + target_token.actor.system.handling;
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve gang up handling for melee attacks and integrate it into damage resolution.

New Features:
- Apply gang up bonuses to melee damage rolls when enabled on the attacker.

Bug Fixes:
- Correct gang up bonus calculation, including handling of allies, enemies, Formation Fighter, Block/Improved Block, and effect-based modifiers.
- Ensure card targets resolve to token objects instead of token documents when reading selected targets.

Enhancements:
- Refine target-number calculation to use the updated gang up logic and clean up related distance/scale helper flows.