### PR TITLE
Power fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Version 5.5.1
+* Bolt mods no longer show up on minor bolt
+* PP management no longer shows epic mods if the actor does not have the edge
+
 # Version 5.5.0
 * Updated the gang up calculation to match the system
 * Added pre-release support for the new gang up flags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
-# Version 5.5.1
+# Version 5.6.0
+* Added better support of the no power points setting
 * Bolt mods no longer show up on minor bolt
 * PP management no longer shows epic mods if the actor does not have the edge
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -267,6 +267,7 @@
   "BRSW.PP": "Power Points",
   "BRSW.PPCost": "Cost",
   "BRSW.PPCurrent": "Current PP",
+  "BRSW.PPPenalty": "PP Penalty",
   "BRSW.PPManagement.BennyRecharge": "Recharge",
   "BRSW.PPManagement.Button": "PP Management",
   "BRSW.PPManagement.GenericMods": "Generic",

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -2,6 +2,7 @@
 /* globals game, ChatPopout, console, canvas, Hooks, renderTemplate, TextEditor, ChatMessage,
      Roll, CONST */
 
+import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { TraitRoll } from "./rolls.js";
 import { broofa, getAuthor, getWhisperData, SettingsUtils, Utils } from "./utils.js";
 import { calc_pp_cost } from "./item_card.js";
@@ -589,20 +590,23 @@ export class BrCommonCard {
     ) {
       return;
     }
+    const ppCost = calc_pp_cost(this);
+    const penaltySelections = Utils.getNoPPPenaltySelections(ppCost);
+
     const action_array = [];
-    for (let penalty = -1; penalty > -7; penalty--) {
+    for (let penalty = 1; penalty <= BRSW2_CONFIG.MAX_NOPP_PENALTY_ACTION; ++penalty) {
       const new_action = new brAction(
-        `PP ${penalty}`,
+        `PP ${-penalty}`,
         {
-          name: `${game.i18n.localize("BRSW.NoPP")} ${penalty}`,
-          id: `no_pp_${-penalty}`,
-          skillMod: penalty,
+          name: `${game.i18n.localize("BRSW.NoPP")} ${-penalty}`,
+          id: `no_pp_${penalty}`,
+          skillMod: -penalty,
         },
         "no_pp",
       );
-      if (penalty === -Math.ceil(this.item.system.pp / 2)) {
-        new_action.selected = true;
-      }
+
+      new_action.selected = penaltySelections.includes(penalty);
+
       action_array.push(new_action);
     }
     this.action_sections["power"] ??= { action_groups: {} };
@@ -610,7 +614,6 @@ export class BrCommonCard {
       name: game.i18n.localize("BRSW.NoPP"),
       actions: action_array,
       id: broofa(),
-      single_choice: true,
     };
   }
 
@@ -823,6 +826,8 @@ export class BrCommonCard {
     );
     data.show_popup_button = SettingsUtils.getUserSetting("popout_chat_button");
     data.showShotsPPInfo = SettingsUtils.getWorldSetting("show_pp_shots_info");
+    data.noPowerPoints = game.settings.get("swade", "noPowerPoints");
+    data.ppPenalty = -Math.ceil(this.pp_cost / 2);
     data.shots_pp_info = data.showShotsPPInfo ? this.item_shots : "";
     data.applicable_effects = this.applicable_effects;
     return data;

--- a/scripts/actions/power-modifiers.js
+++ b/scripts/actions/power-modifiers.js
@@ -84,7 +84,12 @@ export const POWER_MODIFIERS = [
     dmgOverride: "3d6x",
     and_selector: [
       { selector_type: "item_type", selector_value: "power" },
-      { selector_type: "item_name", selector_value: "Bolt" }
+      { selector_type: "item_name", selector_value: "Bolt" },
+      {
+          not_selector: [
+              { selector_type: "item_name", selector_value: "Minor Bolt" }
+          ]
+      },
     ],
     section: "power",
     group: "BRSW.PowerModifiers.PowerModifiers"
@@ -98,6 +103,11 @@ export const POWER_MODIFIERS = [
     and_selector: [
       { selector_type: "item_type", selector_value: "power" },
       { selector_type: "item_name", selector_value: "Bolt" },
+      {
+          not_selector: [
+              { selector_type: "item_name", selector_value: "Minor Bolt" }
+          ]
+      },
       { selector_type: "actor_has_arcane_mastery", selector_value: true }
     ],
     section: "power",
@@ -111,6 +121,11 @@ export const POWER_MODIFIERS = [
     and_selector: [
       { selector_type: "item_type", selector_value: "power" },
       { selector_type: "item_name", selector_value: "Bolt" },
+      {
+          not_selector: [
+              { selector_type: "item_name", selector_value: "Minor Bolt" }
+          ]
+      },
       { selector_type: "actor_has_arcane_mastery", selector_value: true }
     ],
     section: "power",

--- a/scripts/actions/power-modifiers.js
+++ b/scripts/actions/power-modifiers.js
@@ -20,6 +20,16 @@
 
 */
 
+const BOLT_SELECTOR = [
+  { selector_type: "item_type", selector_value: "power" },
+  { selector_type: "item_name", selector_value: "Bolt" },
+  {
+      not_selector: [
+          { selector_type: "item_name", selector_value: "Minor Bolt" }
+      ]
+  },
+];
+
 export const POWER_MODIFIERS = [
   // BARRIER (S)
   {
@@ -83,13 +93,7 @@ export const POWER_MODIFIERS = [
     button_name: "BRSW.PowerModifiers.BoltDamage",
     dmgOverride: "3d6x",
     and_selector: [
-      { selector_type: "item_type", selector_value: "power" },
-      { selector_type: "item_name", selector_value: "Bolt" },
-      {
-          not_selector: [
-              { selector_type: "item_name", selector_value: "Minor Bolt" }
-          ]
-      },
+      ...BOLT_SELECTOR
     ],
     section: "power",
     group: "BRSW.PowerModifiers.PowerModifiers"
@@ -101,13 +105,7 @@ export const POWER_MODIFIERS = [
     dmgOverride: "4d6x",
     isHeavyWeapon: true,
     and_selector: [
-      { selector_type: "item_type", selector_value: "power" },
-      { selector_type: "item_name", selector_value: "Bolt" },
-      {
-          not_selector: [
-              { selector_type: "item_name", selector_value: "Minor Bolt" }
-          ]
-      },
+      ...BOLT_SELECTOR,
       { selector_type: "actor_has_arcane_mastery", selector_value: true }
     ],
     section: "power",
@@ -119,13 +117,7 @@ export const POWER_MODIFIERS = [
     button_name: "BRSW.PowerModifiers.BoltRateOfFire",
     rof: "2",
     and_selector: [
-      { selector_type: "item_type", selector_value: "power" },
-      { selector_type: "item_name", selector_value: "Bolt" },
-      {
-          not_selector: [
-              { selector_type: "item_name", selector_value: "Minor Bolt" }
-          ]
-      },
+      ...BOLT_SELECTOR,
       { selector_type: "actor_has_arcane_mastery", selector_value: true }
     ],
     section: "power",

--- a/scripts/brsw2-config.js
+++ b/scripts/brsw2-config.js
@@ -95,6 +95,12 @@ export const UNTRAINED_SKILLS = [
   "(unskilled)",
 ];
 
+export const ARCANE_MASTERY_EDGES = [
+  "BRSW.EdgeName.ArcaneMastery",
+  "BRSW.EdgeName.DivineMastery",
+  "BRSW.EdgeName.Epic-Mastery",
+];
+
 /**
 / Translation map for attributes
 */

--- a/scripts/brsw2-config.js
+++ b/scripts/brsw2-config.js
@@ -101,6 +101,8 @@ export const ARCANE_MASTERY_EDGES = [
   "BRSW.EdgeName.Epic-Mastery",
 ];
 
+export const MAX_NOPP_PENALTY_ACTION = 6;
+
 /**
 / Translation map for attributes
 */

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -43,11 +43,6 @@ export const BRSW_CONST = {
   TYPE_UNSHAKE_CARD: 13,
   TYPE_UNSTUN_CARD: 14,
   TYPE_RESULT_CARD: 100,
-  ARCANE_MASTERY_EDGES: [
-    "BRSW.EdgeName.ArcaneMastery",
-    "BRSW.EdgeName.DivineMastery",
-    "BRSW.EdgeName.Epic-Mastery",
-  ],
 };
 
 /**

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -317,14 +317,8 @@ export function check_selector(type, value, item, actor) {
       selected = selected || !!edge;
     }
   } else if (type === "actor_has_arcane_mastery") {
-    const edge_names = BRSW_CONST.ARCANE_MASTERY_EDGES.map((edge) => game.i18n.localize(edge).toLowerCase());
-    const edge = actor.items.find((item) => {
-      return (
-        item.type === "edge" &&
-        edge_names.some((edge_name) => item.name.toLowerCase().includes(edge_name))
-      );
-    });
-    selected = !!edge == value;
+    const hasMastery = Utils.actorHasArcaneMastery(actor);
+    selected = hasMastery == value;
   } else if (type === "target_has_hindrance") {
     const hindrance_name = game.i18n.localize(value);
     for (const targeted_token of game.user.targets) {

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -464,6 +464,7 @@ export function activate_item_card_listeners(br_card, html) {
             ev.target.parentElement.querySelector(".brsw-shots-pp").innerText =
                 br_card.item_shots;
         });
+
     html
         .querySelector(".brsw-pp-manual")
         ?.addEventListener("click", async (ev) => {
@@ -471,14 +472,21 @@ export function activate_item_card_listeners(br_card, html) {
 
             if (SettingsUtils.getWorldSetting("show_pp_shots_info")) {
                 //Update the pp text of the card we just clicked on.
-                //This won't affect change the popout or vice versa,
+                //This won't affect the popout or vice versa,
                 //but doing that would require an update to the chat message which would refresh the render which is disruptive
-                const pp_remaining = ev.target.parentElement.parentElement.querySelector(".brsw-shots-pp");
-                pp_remaining.innerText = br_card.item_shots;
-                const pp_cost = ev.target.parentElement.parentElement.querySelector(".brsw-pp-cost");
-                pp_cost.innerText = calc_pp_cost(br_card);
+                if (game.settings.get("swade", "noPowerPoints")) {
+                    const ppPenalty = ev.target.parentElement.parentElement.querySelector(".brsw-pp-penalty");
+                    ppPenalty.innerText = -Math.ceil(calc_pp_cost(br_card) / 2);
+                } else {
+                    const ppRemaining = ev.target.parentElement.parentElement.querySelector(".brsw-shots-pp");
+                    ppRemaining.innerText = br_card.item_shots;
+
+                    const ppCost = ev.target.parentElement.parentElement.querySelector(".brsw-pp-cost");
+                    ppCost.innerText = calc_pp_cost(br_card);
+                }
             }
         });
+
     addEventListenerAll(html, ".brsw-apply-damage", "click", (ev) => {
         create_damage_card(
             ev.currentTarget.dataset.token,
@@ -656,6 +664,10 @@ export async function displayPPChangeCard(actor, chatData) {
  * @param prevSpentPP PP we already spent on a previous roll
  */
 export async function spendPP(br_card, prevSpentPP) {
+    if (game.settings.get("swade", "noPowerPoints")) {
+        return 0;
+    }
+
     prevSpentPP ??= 0;
     const actor = br_card.actor;
     const item = br_card.item;

--- a/scripts/pp_management_dialog.js
+++ b/scripts/pp_management_dialog.js
@@ -1,3 +1,4 @@
+import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { calc_pp_cost, displayPPChangeCard } from "./item_card.js";
 import { Utils } from "./utils.js";
 
@@ -58,6 +59,16 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
         this.refreshPPCost();
       },
       set: async function (event, button) {
+        if (game.settings.get("swade", "noPowerPoints")) {
+          const ppCost = calc_pp_cost(this.brCard);
+          const penaltySelections = Utils.getNoPPPenaltySelections(ppCost);
+
+          const noPPActionGroup = this.brCard.action_sections["power"].action_groups[game.i18n.localize("BRSW.NoPP")];
+          for (let penalty = 0; penalty < BRSW2_CONFIG.MAX_NOPP_PENALTY_ACTION; ++penalty) {
+            noPPActionGroup.actions[penalty].selected = penaltySelections.includes(penalty + 1);
+          }
+        }
+
         await this.brCard.render();
         await this.brCard.save();
         this.close({ revertChanges: false });
@@ -106,6 +117,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
         this.brCard.pp_modifiers.powerMods.filter((m) => !m.isEpic);
 
     const ppCost = calc_pp_cost(this.brCard);
+    const noPowerPoints = game.settings.get("swade", "noPowerPoints");
 
     return {
       genericMods: this.brCard.pp_modifiers.genericMods,
@@ -116,6 +128,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
       isArcaneDevice,
       hasSoulDrain,
       ppCost,
+      noPowerPoints,
     };
   };
 
@@ -211,7 +224,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
       currentPP,
       maxPP,
       dataKey
-    }
+    };
   }
 
   bennyRechargePP() {

--- a/scripts/pp_management_dialog.js
+++ b/scripts/pp_management_dialog.js
@@ -1,4 +1,5 @@
 import { calc_pp_cost, displayPPChangeCard } from "./item_card.js";
+import { Utils } from "./utils.js";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
@@ -98,11 +99,17 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
     const soulDrainName = game.i18n.localize("BRSW.EdgeName.SoulDrain").toLowerCase();
     const hasSoulDrain = !!actor.items.find((item) => { return (item.type === "edge" && item.name.toLowerCase().includes(soulDrainName)); });
 
+    const hasArcaneMastery = Utils.actorHasArcaneMastery(actor);
+    const powerMods =
+      hasArcaneMastery ?
+        this.brCard.pp_modifiers.powerMods :
+        this.brCard.pp_modifiers.powerMods.filter((m) => !m.isEpic);
+
     const ppCost = calc_pp_cost(this.brCard);
 
     return {
       genericMods: this.brCard.pp_modifiers.genericMods,
-      powerMods: this.brCard.pp_modifiers.powerMods,
+      powerMods: powerMods,
       additionalRecipientsMod: this.brCard.pp_modifiers.additionalRecipientsMod,
       extraCost: this.brCard.pp_modifiers.extraCost,
       bennyImage,

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -418,8 +418,7 @@ function shouldUseScale(origin_actor, target_token, item, skill) {
         return Utils.isFightingSkill(skill) || Utils.isShootingSkill(skill) || Utils.isThrowingSkill(skill);
     }
 
-    if (item.type === "weapon") return true;
-    if (item.type === "power" && item.name.toLowerCase().includes("bolt")) return true;
+    if (Utils.isWeaponOrBolt(item)) return true;
 
     return false;
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -563,6 +563,22 @@ export class Utils {
 
     return !!edge;
   }
+
+  static getNoPPPenaltySelections(ppCost) {
+    const result = [];
+    if (ppCost === 0) return result;
+
+    let penalty = Math.ceil(ppCost / 2);
+
+    for (let p = BRSW2_CONFIG.MAX_NOPP_PENALTY_ACTION; p >= 1 && penalty > 0; --p) {
+      if (penalty >= p) {
+        result.push(p);
+        penalty -= p;
+      }
+    }
+
+    return result;
+  }
 }
 
 export class SettingsUtils {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -551,6 +551,18 @@ export class Utils {
     trait = trait ?? Utils.getItemTrait(item, actor);
     return item.system.isRanged && (!item.system.isMelee || trait?.system.swid !== 'fighting');
   }
+
+  static actorHasArcaneMastery(actor) {
+    const edgeNames = BRSW2_CONFIG.ARCANE_MASTERY_EDGES.map((edge) => game.i18n.localize(edge).toLowerCase());
+    const edge = actor.items.find((item) => {
+      return (
+        item.type === "edge" &&
+        edgeNames.some((edgeName) => item.name.toLowerCase().includes(edgeName))
+      );
+    });
+
+    return !!edge;
+  }
 }
 
 export class SettingsUtils {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -554,7 +554,7 @@ export class Utils {
 
   static actorHasArcaneMastery(actor) {
     const edgeNames = BRSW2_CONFIG.ARCANE_MASTERY_EDGES.map((edge) => game.i18n.localize(edge).toLowerCase());
-    const edge = actor.items.find((item) => {
+    const edge = actor?.items.find((item) => {
       return (
         item.type === "edge" &&
         edgeNames.some((edgeName) => item.name.toLowerCase().includes(edgeName))

--- a/templates/item_card.hbs
+++ b/templates/item_card.hbs
@@ -41,20 +41,29 @@
             {{#if is_power}}
                 <span class="brws-common-modifiers brsw-form twbr:flex twbr:grow twbr:gap-1">
                     {{#if showShotsPPInfo}}
+                        {{#if noPowerPoints}}
                         <div class="twbr:self-center">
-                            <span class="twbr:font-bold">{{localize "BRSW.PPCurrent"}}: </span>
-                            <span class="brsw-shots-pp">{{shots_pp_info}}</span>
+                            <span class="twbr:font-bold">{{localize "BRSW.PPPenalty"}}: </span>
+                            <span class="brsw-pp-penalty">{{ppPenalty}}</span>
                         </div>
+                        {{else}}
+                            <div class="twbr:self-center">
+                                <span class="twbr:font-bold">{{localize "BRSW.PPCurrent"}}: </span>
+                                <span class="brsw-shots-pp">{{shots_pp_info}}</span>
+                            </div>
                         <div class="twbr:self-center">
                             <span class="twbr:font-bold">{{localize "BRSW.PPCost"}}: </span>
                             <span class="brsw-pp-cost">{{pp_cost}}</span>
                         </div>
+                        {{/if}}
                     {{/if}}
                     <div class="twbr:flex twbr:ml-auto">
-                        <img src="modules/betterrolls-swade2/assets/electric.svg" alt="power point" title="{{localize 'BRSW.SubtractPP'}}" class="twbr:w-6 brsw-pp-toggle twbr:cursor-pointer twbr:border twbr:border-solid
+                        {{#unless noPowerPoints}}
+                            <img src="modules/betterrolls-swade2/assets/electric.svg" alt="power point" title="{{localize 'BRSW.SubtractPP'}}" class="twbr:w-6 brsw-pp-toggle twbr:cursor-pointer twbr:border twbr:border-solid
                                             twbr:border-slate-400 twbr:m-1 twbr:rounded twbr:hover:ring-2 twbr:hover:ring-offset-1
                                             {{#if subtractPP}}twbr:bg-red-700{{else}}twbr:bg-gray-500{{/if}}
                                             twbr:hover:bg-gray-900">
+                        {{/unless}}
                         <img src="modules/betterrolls-swade2/assets/magic-swirl.svg" alt="reload" title="{{localize 'BRSW.PPManagement.Button'}}" class="twbr:w-6 brsw-pp-manual twbr:cursor-pointer twbr:bg-transparent twbr:border
                                             twbr:border-solid twbr:border-slate-400 twbr:m-1 twbr:rounded twbr:hover:ring-2
                                             twbr:hover:ring-offset-1 twbr:hover:invert">

--- a/templates/pp_management_dialog.hbs
+++ b/templates/pp_management_dialog.hbs
@@ -38,7 +38,9 @@
     </div>
     <footer class="form-footer">
         <button type="button" data-action="set">{{localize "BRSW.PPManagement.Set"}}</button>
-        <button type="button" id="ppCost" data-action="spendPP">{{localize "BRSW.PPManagement.Spend" ppCost=ppCost}}</button>
+        {{#unless noPowerPoints}}
+            <button type="button" id="ppCost" data-action="spendPP">{{localize "BRSW.PPManagement.Spend" ppCost=ppCost}}</button>
+        {{/unless}}
         {{#unless isArcaneDevice}}
             <button type="button" data-action="recharge">
                 <img src="{{{bennyImage}}}" class="brsw-button-image">


### PR DESCRIPTION
## Summary by Sourcery

Ensure power modifiers and power point options respect arcane mastery and bolt variants.

New Features:
- Add shared configuration and utility helper for detecting actors with arcane mastery edges.

Bug Fixes:
- Prevent standard Bolt power modifiers from applying to Minor Bolt.
- Hide epic power modifiers in PP management when the actor lacks an appropriate arcane mastery edge.

Enhancements:
- Centralize arcane mastery edge handling in Utils and reuse it in selector checks and the PP management dialog.
- Reuse a common helper when deciding whether scale rules apply to weapons or Bolt powers.

Documentation:
- Document the bolt and epic power modifier behavior changes in the changelog.