### PR TITLE
Popout fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 # Version 5.8.1
-* Fixed adding fixed damage
+* Fixed popout showing when disconnected users connect
+* Fixed error when adding fixed damage
 
 # Version 5.8.0
 * Added exclusiveGroup to generic PP mods

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -55,7 +55,7 @@ export class BrCommonCard {
         this.update_list = {}; // List of properties pending to be updated
         this.resist_buttons = [];
         this.trait_roll = new TraitRoll();
-        this.popup_shown = false;
+        this.popoutShown = false;
         this.manual_mods = {};
         this.applicable_effects = [];
         this.pp_modifiers = {};
@@ -87,35 +87,38 @@ export class BrCommonCard {
         this.update_list = {};
     }
 
-    create_popout() {
-        if (game.user.id !== this.message.author.id || this.popup_shown) {
+    createPopout() {
+        if (game.user.id !== this.message.author.id || this.popoutShown) {
             return;
         }
+
         if (SettingsUtils.getUserSetting("auto_popout_chat")) {
-            this.show_popup();
+            this.showPopout();
         }
     }
 
-    show_popup() {
-        const top =
-            cascade_starting_left + game.brsw.cascade_count * cascade_left_increment;
-        const left =
-            cascade_starting_top + game.brsw.cascade_count * cascade_top_increment;
+    showPopout() {
+        const top = cascade_starting_left + game.brsw.cascade_count * cascade_left_increment;
+        const left = cascade_starting_top + game.brsw.cascade_count * cascade_top_increment;
+
         game.brsw.cascade_count =
             game.brsw.cascade_count + 1 < cascade_max_cascades
                 ? game.brsw.cascade_count + 1
                 : 0;
+
         new CONFIG.ChatMessage.popoutClass({
             message: this.message,
             position: { top: top, left: left },
         }).render(true);
-        this.popup_shown = true;
+
+        this.popoutShown = true;
+
         this.save().catch(() => {
-            console.error("Error saving card data after popup rendering");
+            console.error("Error saving card data after popout rendering");
         });
     }
 
-    close_popout() {
+    closePopout() {
         for (const app of Object.values(this.message.apps)) {
             if (app.constructor.name === "ChatPopout") {
                 app.close();
@@ -145,7 +148,7 @@ export class BrCommonCard {
             trait_roll: this.trait_roll,
             resist_buttons: this.resist_buttons,
             damage: this.damage,
-            popup_shown: this.popup_shown,
+            popoutShown: this.popoutShown,
             manual_mods: this.manual_mods,
             applicable_effects: this.applicable_effects,
             pp_modifiers: this.pp_modifiers,
@@ -171,7 +174,7 @@ export class BrCommonCard {
             "macro_buttons",
             "resist_buttons",
             "damage",
-            "popup_shown",
+            "popoutShown",
             "manual_mods",
             "applicable_effects",
             "pp_modifiers",
@@ -188,8 +191,8 @@ export class BrCommonCard {
             );
         }
         //Backwards compatibility so that we don't show a bunch of old popouts
-        if (data.popup_shown_to?.length > 0) {
-            data.popup_shown = true;
+        if (data.popup_shown !== undefined) {
+            this.popoutShown = true;
         }
     }
 
@@ -797,6 +800,14 @@ export class BrCommonCard {
             this.update_list.content = new_content;
         } else {
             await this.create_foundry_message(new_content);
+
+            //If auto-popout is disabled, mark our popout as shown so that we won't show a bunch of old popouts if it's later enabled
+            this.popoutShown = !SettingsUtils.getUserSetting("auto_popout_chat");
+
+            if (!this.message.author.active) {
+                //If the author isn't connected, mark the popout as shown so that we don't pop it out when they connect
+                this.popoutShown = true;
+            }
         }
     }
 
@@ -824,7 +835,7 @@ export class BrCommonCard {
             this.skill ||
             this.damage
         );
-        data.show_popup_button = SettingsUtils.getUserSetting("popout_chat_button");
+        data.showPopoutButton = SettingsUtils.getUserSetting("popout_chat_button");
         data.showShotsPPInfo = SettingsUtils.getWorldSetting("show_pp_shots_info");
         data.noPowerPoints = game.settings.get("swade", "noPowerPoints");
         data.ppPenalty = -Math.ceil(this.pp_cost / 2);

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -167,8 +167,8 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     }
 
     if (Object.keys(message.apps).length < 1) {
-      // Don't create popout when rendering popouts.
-      card.create_popout();
+      // Don't create a popout when rendering popouts
+      card.createPopout();
     }
 
     const headerTitle = html.querySelector(".brsw-header-title");

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -84,6 +84,7 @@ export function create_common_card(origin, render_data, template) {
   } else {
     actor = origin;
   }
+
   if (render_data.tooltip) {
     render_data.tooltip = // Limit tooltip size.
       render_data.tooltip.length <
@@ -91,13 +92,16 @@ export function create_common_card(origin, render_data, template) {
         ? render_data.tooltip
         : null;
   }
+
   const br_message = new BrCommonCard(undefined);
   br_message.actor_id = actor.id;
+
   if (actor !== origin) {
     br_message.token_id = origin.id;
   } else if (actor.isToken) {
     br_message.token_id = actor.token.id;
   }
+
   br_message.generate_render_data(render_data, template);
   return br_message;
 }
@@ -380,7 +384,7 @@ export function activate_common_listeners(br_card, html) {
     });
   // Popout card
   html.querySelector(".brsw-popout-button")?.addEventListener("click", () => {
-    br_card.show_popup();
+    br_card.showPopout();
   });
 }
 

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -68,7 +68,7 @@ export async function create_damage_card(
   );
   if (wounds === 0) {
     //If we're not dealing any wounds, don't bother popping out the card since there's no action required
-    br_message.popup_shown = true;
+    br_message.popoutShown = true;
   }
   br_message.update_list = { ...br_message.update_list, ...{ user: user.id } };
   br_message.type = BRSW_CONST.TYPE_DMG_CARD;
@@ -234,7 +234,7 @@ export function activate_damage_card_listeners(message, html) {
   });
   html.querySelector(".brsw-show-incapacitation")?.addEventListener("click", () => {
     // noinspection JSIgnoredPromiseFromCall
-    br_card.close_popout(); //We assume we're done with the card at this point so close any popouts
+    br_card.closePopout(); //We assume we're done with the card at this point so close any popouts
     create_incapacitation_card(br_card.token_id).catch(() => {
       console.error("Error creating incapacitation card");
     });

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -136,7 +136,7 @@ export function activate_incapacitation_card_listeners(message, html) {
   });
   html.querySelector(".brsw-injury-button")?.addEventListener("click", (ev) => {
     // noinspection JSIgnoredPromiseFromCall
-    br_card.close_popout(); //We assume we're done with the card at this point so close any popouts
+    br_card.closePopout(); //We assume we're done with the card at this point so close any popouts
     create_injury_card(
       br_card.token_id,
       ev.currentTarget.dataset.injuryType,
@@ -276,7 +276,7 @@ export async function create_injury_card(token_id, reason) {
   );
   br_message.update_list = { ...br_message.update_list, ...{ user: user.id } };
   br_message.type = BRSW_CONST.TYPE_INJ_CARD;
-  br_message.popup_shown = true; //The injury result has no action, so we don't show the popout
+  br_message.popoutShown = true; //The injury result has no action, so we don't show the popout
   await br_message.render();
   await br_message.save();
   Hooks.call("BRSW-InjuryAEApplied", br_message, injury_effect, reason);

--- a/templates/common_card_header.hbs
+++ b/templates/common_card_header.hbs
@@ -41,7 +41,7 @@
                           twbr:hover:ring-offset-1 twbr:hover:cursor-pointer" src="{{{header.img}}}" alt="Item image">
       {{/if}}
     </div>
-    {{#if show_popup_button}}
+    {{#if showPopoutButton}}
       <button class="brsw-popout-button twbr:font-medium twbr:ml-1 twbr:w-8 twbr:h-8 twbr:min-w-8 twbr:align-top
                       twbr:focus:outline-hidden twbr:bg-white twbr:rounded twbr:border twbr:border-solid
                       twbr:focus:z-10 twbr:focus:ring-4 twbr:focus:ring-gray-700 twbr:text-gray-800


### PR DESCRIPTION
## Summary by Sourcery

Normalize and harden chat card popout behavior and naming, preventing unwanted or repeated popouts, especially for disconnected users and older messages.

Bug Fixes:
- Ensure chat card popouts are not repeatedly shown when users reconnect or when auto-popout settings change.
- Fix legacy popup state handling to avoid showing popouts for old messages.
- Prevent popouts from opening when damage or injury cards have no actionable content.

Enhancements:
- Refine popout-related naming and template bindings for consistency across code and templates.

Documentation:
- Update changelog entry for version 5.8.1 with the corrected description of popout and fixed damage fixes.