### PR TITLE
Improved measuring and gang up calculation for edge measurement and gridless scenes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 # Version 5.9.0
 * Added Tamil
 * Fixed gang up range check for diagonals
+* Improved edge measurement
+* Fixed gang up calculation when using edge measurement
 
 # Version 5.8.1
 * Fixed popout showing when disconnected users connect

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -552,7 +552,7 @@ export function calculateGangUp(attackerToken, targetToken) {
         0 : //0 when using edge distance since edges have to be touching
         Math.SQRT2; //Range is SQRT2 to account for diagonals
 
-    if (game.scenes.current.grid.isGridless) {
+    if (scene.grid.isGridless) {
         //If we're gridless, give a bit of extra buffer so placement doesn't have to be so exact
         meleeRange += 0.5;
     }

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -548,7 +548,14 @@ export function calculateGangUp(attackerToken, targetToken) {
     const scene = targetToken.scene;
     if (!scene) return 0;
 
-    const meleeRange = Math.SQRT2; //Range is SQRT2 to account for diagonals
+    let meleeRange = SettingsUtils.getWorldSetting("measure_from_edge") ?
+        0 : //0 when using edge distance since edges have to be touching
+        Math.SQRT2; //Range is SQRT2 to account for diagonals
+
+    if (game.scenes.current.grid.isGridless) {
+        //If we're gridless, give a bit of extra buffer so placement doesn't have to be so exact
+        meleeRange += 0.5;
+    }
 
     const formationFighterName = game.i18n.localize("BRSW.EdgeName.FormationFighter").toLowerCase();
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -297,12 +297,23 @@ export function measureDistance(tokenA, tokenB) {
             }
         }
     }
+
     let measured_distance = measurePath([
         closestPair.a.coords,
         closestPair.b.coords,
     ]);
+
     if (SettingsUtils.getWorldSetting("measure_from_edge")) {
-        measured_distance -= game.scenes.current.grid.distance;
+        //If we're measuring from the edge, we need to offset from the center of the grid space to the edge
+        //To do this, we need to find the intersection distance from center to edge based on the angle between the two tokens
+        const dist = Math.sqrt(closestPair.dist);
+        const dir = {
+            x: (closestPair.b.coords.x - closestPair.a.coords.x) / dist,
+            y: (closestPair.b.coords.y - closestPair.a.coords.y) / dist,
+        };
+
+        const distanceToEdge = (game.scenes.current.grid.distance / 2) / Math.max(Math.abs(dir.x), Math.abs(dir.y));
+        measured_distance -= (distanceToEdge * 2); //Times 2 because we're offsetting the distance for both tokens
     }
     return measured_distance;
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -307,14 +307,17 @@ export function measureDistance(tokenA, tokenB) {
         //If we're measuring from the edge, we need to offset from the center of the grid space to the edge
         //To do this, we need to find the intersection distance from center to edge based on the angle between the two tokens
         const dist = Math.sqrt(closestPair.dist);
-        const dir = {
-            x: (closestPair.b.coords.x - closestPair.a.coords.x) / dist,
-            y: (closestPair.b.coords.y - closestPair.a.coords.y) / dist,
-        };
+        if (dist > 0) {
+            const dir = {
+                x: (closestPair.b.coords.x - closestPair.a.coords.x) / dist,
+                y: (closestPair.b.coords.y - closestPair.a.coords.y) / dist,
+            };
 
-        const distanceToEdge = (game.scenes.current.grid.distance / 2) / Math.max(Math.abs(dir.x), Math.abs(dir.y));
-        measured_distance -= (distanceToEdge * 2); //Times 2 because we're offsetting the distance for both tokens
+            const distanceToEdge = (tokenA.scene.grid.distance / 2) / Math.max(Math.abs(dir.x), Math.abs(dir.y));
+            measured_distance -= (distanceToEdge * 2); //Times 2 because we're offsetting the distance for both tokens
+        }
     }
+
     return measured_distance;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Adjust distance measurement and melee gang-up detection to correctly handle edge-based measuring and gridless scenes.

New Features:
- Support edge-based distance offsets when measuring between tokens so that ranges are calculated from token edges instead of grid centers.
- Allow melee gang-up range to adapt based on edge-measurement settings and provide additional tolerance on gridless scenes.