### PR TITLE
Settings

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -289,27 +289,32 @@ function registerUserSettings() {
     });
 }
 
+function cacheSettings(savedSettings, settingsCache) {
+    for (const key in settingsCache) {
+        if (Object.hasOwn(savedSettings, key)) {
+            if (savedSettings[key].name !== undefined) {
+                //If we have a name, this is old data which means we need to migrate it to the new structure
+                if (savedSettings[key].value === savedSettings[key].default ||
+                    savedSettings[key].value === settingsCache[key].default) {
+                    //If the old value was the old default or is the new default,
+                    //we'll use the current default which means we don't need a value
+                    continue;
+                }
+
+                settingsCache[key].value = savedSettings[key].value;
+                continue;
+            }
+
+            settingsCache[key].value = savedSettings[key];
+        }
+    }
+}
+
 export function updateCachedWorldSettings() {
     //Update our cached world settings with our saved data
     const worldSettings = SettingsUtils.getSetting(BRSW2_CONFIG.SETTING_KEYS.worldSettings);
     if (worldSettings) {
-        for (const key in BRSW2_CONFIG.WORLD_SETTINGS) {
-            if (Object.hasOwn(worldSettings, key)) {
-                //Migrate old data to the new structure
-                if (worldSettings[key].name !== undefined) {
-                    if (worldSettings[key].value === worldSettings[key].default) {
-                        //If the old value was the old default, use the current default
-                        BRSW2_CONFIG.WORLD_SETTINGS[key].value = BRSW2_CONFIG.WORLD_SETTINGS[key].default;
-                    } else {
-                        BRSW2_CONFIG.WORLD_SETTINGS[key].value = worldSettings[key].value;
-                    }
-                    continue;
-                }
-
-                BRSW2_CONFIG.WORLD_SETTINGS[key].value = worldSettings[key];
-            }
-        }
-
+        cacheSettings(worldSettings, BRSW2_CONFIG.WORLD_SETTINGS);
         SettingsUtils.setWorldSettings();
     }
 }
@@ -318,23 +323,7 @@ export function updateCachedUserSettings() {
     //Update our cached user settings from the user's flags
     const userSettings = SettingsUtils.getModuleFlag(game.user, BRSW2_CONFIG.USER_FLAGS.userSettings);
     if (userSettings) {
-        for (const key in BRSW2_CONFIG.USER_SETTINGS) {
-            if (Object.hasOwn(userSettings, key)) {
-                //Migrate old data to the new structure
-                if (userSettings[key].name !== undefined) {
-                    if (userSettings[key].value === userSettings[key].default) {
-                        //If the old value was the old default, use the current default
-                        BRSW2_CONFIG.USER_SETTINGS[key].value = BRSW2_CONFIG.USER_SETTINGS[key].default;
-                    } else {
-                        BRSW2_CONFIG.USER_SETTINGS[key].value = userSettings[key].value;
-                    }
-                    continue;
-                }
-
-                BRSW2_CONFIG.USER_SETTINGS[key].value = userSettings[key];
-            }
-        }
-
+        cacheSettings(userSettings, BRSW2_CONFIG.USER_SETTINGS);
         SettingsUtils.setUserSettings();
     }
 }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -698,6 +698,10 @@ export class SettingsUtils {
     }
 
     static async setWorldSettings() {
+        if (!game.user.hasPermission("SETTINGS_MODIFY")) {
+            return;
+        }
+
         const worldSettings = Object.fromEntries(
             Object.entries(BRSW2_CONFIG.WORLD_SETTINGS).filter(([key, value]) => value.value !== undefined && value.value !== value.default).map(([key, value]) => [
                 key,
@@ -854,30 +858,40 @@ export class TelemetryUtils {
 
     static sendModuleReadyEvent() {
         const worldSettings = {};
+        let nonDefaultSettings = [];
 
         Object.entries(BRSW2_CONFIG.WORLD_SETTINGS).forEach(([k, v]) => {
-            worldSettings[k] = v.value;
-            worldSettings[`${k}_is_default`] = v.value === undefined || v.value === v.default;
+            if (v.value !== undefined && v.value !== v.default) {
+                worldSettings[k] = v.value;
+                worldSettings[`${k}_is_default`] = false;
+                nonDefaultSettings.push(k);
+            }
         });
 
         TelemetryUtils.sendTelemetry("module_ready", false, {
             ...worldSettings,
             enabledOptionalRules: SettingsUtils.getSetting(BRSW2_CONFIG.SETTING_KEYS.enabledOptionalRules),
+            nonDefaultSettings,
         });
     }
 
     static sendUserReadyEvent() {
         const userSettings = {};
+        let nonDefaultSettings = [];
 
         Object.entries(BRSW2_CONFIG.USER_SETTINGS).forEach(([k, v]) => {
-            userSettings[k] = v.value;
-            userSettings[`${k}_is_default`] = v.value === undefined || v.value === v.default;
+            if (v.value !== undefined && v.value !== v.default) {
+                userSettings[k] = v.value;
+                userSettings[`${k}_is_default`] = false;
+                nonDefaultSettings.push(k);
+            }
         });
 
         TelemetryUtils.sendTelemetry("user_ready", true, {
             isGM: game.user.isGM,
             lang:game.i18n.lang,
             ...userSettings,
+            nonDefaultSettings,
         });
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor settings caching to be shared between world and user settings and tighten handling of non-default values for persistence and telemetry.

Enhancements:
- Introduce a shared cacheSettings helper to unify migration and caching logic for world and user settings, avoiding storage of default values.
- Restrict world settings persistence to users with SETTINGS_MODIFY permission.
- Adjust telemetry to only include non-default world and user settings and report their keys separately.