### PR TITLE
Damage fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Version 5.16.1
+* Fixed a bunch of issues with damage formulas
+* The damage section now only appears if the item has damage or while an action with damage is selected
+
 # Version 5.16.0
 * Added support for Arcane Protection
 * Fixed using complex selectors with defaultChecked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 5.16.1
 * Fixed a bunch of issues with damage formulas
 * The damage section now only appears if the item has damage or while an action with damage is selected
+* Updated Spanish translations (Libertad)
 
 # Version 5.16.0
 * Added support for Arcane Protection

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -626,7 +626,7 @@ export class BrCommonCard {
         });
     }
 
-    refreshPPModsFromActions(actions) {
+    refreshPPModsFromActions() {
         if (this.pp_modifiers.genericMods) {
             for (const mod of this.pp_modifiers.genericMods) {
                 if (mod.actionId) {
@@ -644,6 +644,21 @@ export class BrCommonCard {
                 if (action) {
                     mod.selected = action.selected;
                 }
+            }
+        }
+    }
+
+    refreshDamageFromActions() {
+        if (this.item?.system.damage) {
+            //An item with damage doesn't need refreshing as it will always have damage
+            return;
+        }
+
+        this.damage = false;
+        for (const action of this.getSelectedActions()) {
+            if (action.code.dmgOverride) {
+                this.damage = true;
+                return;
             }
         }
     }

--- a/scripts/actions.js
+++ b/scripts/actions.js
@@ -8,6 +8,7 @@ export class brAction {
     if (type === "item") {
       this.code = JSON.parse(JSON.stringify(code));
       this.code.id = broofa();
+      this.convertCodeProperties();
     } else {
       this.code = code;
     }
@@ -15,7 +16,6 @@ export class brAction {
       this.code.id = idOverride;
     }
     this.selected = false;
-    this.recreate_skill_damage_mods();
     // noinspection JSUnusedGlobalSymbols
     this.has_skill_mod = !!(this.code.skillMod || this.code.skillOverride);
     // noinspection JSUnusedGlobalSymbols
@@ -26,20 +26,24 @@ export class brAction {
     );
   }
 
-  recreate_skill_damage_mods() {
-    // Since SWADE 3.1 modifiers to trait and damage roll no longer share
-    // the same syntax with Global Actions. So we need to recreate them
+  convertCodeProperties() {
+    //SWADE stores its properties generically between trait and damage but BR2 needs them separate
     if (this.code.hasOwnProperty("modifier")) {
-      // Post SWADE 3.1 action
-      this.code = JSON.parse(JSON.stringify(this.code));
       if (this.code.type === "trait") {
         this.code.skillMod = this.code.modifier;
-        this.code.skillOverride = this.code.override;
       } else if (this.code.type === "damage") {
         this.code.dmgMod = this.code.modifier;
+      }
+    }
+
+    if (this.code.hasOwnProperty("override")) {
+      if (this.code.type === "trait") {
+        this.code.skillOverride = this.code.override;
+      } else if (this.code.type === "damage") {
         this.code.dmgOverride = this.code.override;
       }
     }
+
     if (this.code.hasOwnProperty("ap")) {
       this.code.overrideAp = this.code.ap;
     }

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -169,6 +169,12 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
             html.querySelectorAll(".brsw-owner-trusted-only").forEach((e) => e.remove());
         }
 
+        const damageSection = html.querySelector(".brsw-damage-section");
+        if (damageSection) {
+            //If we have damage, show the damage section
+            damageSection.hidden = !br_card.damage;
+        }
+
         if (Object.keys(message.apps).length < 1) { // Don't create a popout when rendering popouts
             card.createPopout();
         }

--- a/scripts/card-dialog.js
+++ b/scripts/card-dialog.js
@@ -97,6 +97,8 @@ class BrCardDialog {
     this.BrCard.setActiveActions(enabled_actions);
     this.BrCard.setTraitUsingSkillOverride();
 
+    this.BrCard.refreshDamageFromActions();
+
     this.BrCard.refreshPPModsFromActions();
 
     await this.BrCard.render();

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -1462,14 +1462,17 @@ export async function roll_dmg(
     const damageTypeMatch = damageFormulas.damage.match(/\[([^\]]+)\]/) ?? damage?.match(/\[([^\]]+)\]/);
     const damageType = damageTypeMatch?.[0];
     if (damageType) {
-        const addDamageType = (formula) =>
-            formula.replace(
-                /(?:\d+)?d\d+x?(?=\[|[^0-9]|$)/g,
-                (match, offset, string) => string[offset + match.length] === "[" ? match : `${match}${damageType}`,
-            );
+        const addDamageType = (formula, damageType) =>
+        formula.replace(
+            /((?:\d+)?d\d+(?:[a-zA-Z]+(?:[<>=]+-?\d+)?)*)/g,
+            (match, captured, offset, string) =>
+                string[offset + match.length] === "["
+                    ? match
+                    : `${match}${damageType}`,
+        );
 
-        damageFormulas.damage = addDamageType(damageFormulas.damage);
-        damageFormulas.raise = addDamageType(damageFormulas.raise);
+        damageFormulas.damage = addDamageType(damageFormulas.damage, damageType);
+        damageFormulas.raise = addDamageType(damageFormulas.raise, damageType);
     }
 
     //Conviction
@@ -1484,7 +1487,7 @@ export async function roll_dmg(
     if (damageFormulas.explodes) {
         damageFormulas.damage = makeExplodable(damageFormulas.damage);
     } else {
-        const removeExplode = (formula) => formula.replace(/((?:\d+)?d\d+)x(?=\[|[^0-9]|$)/g, "$1");
+        const removeExplode = (formula) => formula.replace(/((?:\d+)?d\d+(?:[a-zA-Z]+(?:[<>=]+-?\d+)?)*?)x(?=[a-zA-Z<>=+\-\[]|$)/g, "$1");
         damageFormulas.damage = removeExplode(damageFormulas.damage);
         damageFormulas.raise = removeExplode(damageFormulas.raise);
     }

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -75,16 +75,11 @@ export async function create_item_card(
     }
 
     const description = item.system.description;
-    let damage = item.system.damage;
     const ammoEnabled = parseInt(item.system.shots) || item.system.ammo;
     const is_power = !isNaN(parseFloat(item.system.pp)) || item.type === "power";
     const subtract_select = ammoEnabled
         ? SettingsUtils.getWorldSetting(WORLD_SETTING_KEYS.defaultAmmoManagement)
         : false;
-
-    if (!damage && item.system.actions) {
-        damage = check_for_actions_with_damage(item);
-    }
 
     const trait = Utils.getItemTrait(item, actor);
 
@@ -109,7 +104,7 @@ export async function create_item_card(
         "modules/betterrolls-swade2/templates/item_card.hbs",
     );
     br_message.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD;
-    br_message.damage = damage;
+    br_message.damage = !!item.system.damage;
     br_message.item_id = item_id;
     br_message.applicable_effects = get_applicable_effects(item);
     br_message.pp_modifiers = is_power ? get_pp_mods(item) : {};
@@ -1296,7 +1291,7 @@ function joker_modifiers(br_card, damage_roll) {
     }
 }
 
-async function get_damage_mods_from_actions(
+async function getDamageModsFromActions(
     br_card,
     damageFormulas,
     damage_roll,
@@ -1331,12 +1326,6 @@ async function get_damage_mods_from_actions(
 
         if (action.code.dmgOverride) {
             damageFormulas.damage = action.code.dmgOverride;
-
-            if (damageFormulas.damageType) {
-                //If we have a damage type, set the type on the override
-                //If it already has a type, this regex will do nothing
-                damageFormulas.damage = damageFormulas.damage.replace(/\b(?:\d+)?d\d+\b(?!\[)/g, match => `${match}${damageFormulas.damageType}`);
-            }
         }
 
         if (action.code.self_add_status) {
@@ -1392,25 +1381,6 @@ async function get_damage_mods_from_actions(
 }
 
 /**
- * Gets any damage from any action
- * @param {BrCommonCard} br_card
- */
-function get_any_damage_from_actions(br_card) {
-    let damage = "1";
-    Utils.forEachActionGroup(br_card, group => {
-        for (const action of group.actions) {
-            if (action.code.dmgOverride) {
-                if (action.selected || action.code.dmgOverride != 0) {
-                    damage = action.code.dmgOverride;
-                    return true;
-                }
-            }
-        }
-    });
-    return damage;
-}
-
-/**
  * Rolls damage dor an item
  * @param {BrCommonCard} br_card
  * @param html
@@ -1433,21 +1403,16 @@ export async function roll_dmg(
     const number_raise_dice = item.system.bonusDamageDice || 1;
     let raiseFormula = `+${number_raise_dice}d${raise_die_size}x`;
 
-    const damageTypeMatch = item.system.damage.match(/\[([^\]]+)\]/);
-    const damageType = damageTypeMatch?.[0];
-    if (damageType) {
-        raiseFormula += damageType;
-    }
+    const damage = item.system.damage;
 
     const damageFormulas = {
-        damage: item.system.damage,
+        damage: damage,
         raise: raiseFormula,
         ap: parseInt(item.system.ap),
         multiplier: 1,
         explodes: true,
         heavy_weapon: false,
         location: "torso",
-        damageType: damageType,
     };
 
     const macros = [];
@@ -1459,9 +1424,9 @@ export async function roll_dmg(
     const options = get_roll_options(default_options, br_card);
 
     // Shotgun
-    if (damageFormulas.damage.includes("1-3d6") && item.type === "weapon") {
+    if (damageFormulas.damage?.includes("1-3d6") && item.type === "weapon") {
         // Bet that this is a shotgun
-        damageFormulas.damage = "3d6" + (damageType ?? "");
+        damageFormulas.damage = "3d6";
     }
 
     const damage_roll = { label: "---", brswroll: new BRWSRoll(), raise: raise };
@@ -1485,7 +1450,7 @@ export async function roll_dmg(
     }
 
     // Actions
-    await get_damage_mods_from_actions(
+    await getDamageModsFromActions(
         br_card,
         damageFormulas,
         damage_roll,
@@ -1493,9 +1458,18 @@ export async function roll_dmg(
         expend_bennie,
     );
 
-    if (!damageFormulas.damage) {
-        // Damage is empty and damage action has not been selected...
-        damageFormulas.damage = get_any_damage_from_actions(br_card);
+    //If our selected damage has a type use that otherwise fall back to the type on the item
+    const damageTypeMatch = damageFormulas.damage.match(/\[([^\]]+)\]/) ?? damage?.match(/\[([^\]]+)\]/);
+    const damageType = damageTypeMatch?.[0];
+    if (damageType) {
+        const addDamageType = (formula) =>
+            formula.replace(
+                /(?:\d+)?d\d+x?(?=\[|[^0-9]|$)/g,
+                (match, offset, string) => string[offset + match.length] === "[" ? match : `${match}${damageType}`,
+            );
+
+        damageFormulas.damage = addDamageType(damageFormulas.damage);
+        damageFormulas.raise = addDamageType(damageFormulas.raise);
     }
 
     //Conviction
@@ -1510,8 +1484,9 @@ export async function roll_dmg(
     if (damageFormulas.explodes) {
         damageFormulas.damage = makeExplodable(damageFormulas.damage);
     } else {
-        damageFormulas.damage = damageFormulas.damage.replace("x", "");
-        damageFormulas.raise = damageFormulas.raise.replace("x", "");
+        const removeExplode = (formula) => formula.replace(/((?:\d+)?d\d+)x(?=\[|[^0-9]|$)/g, "$1");
+        damageFormulas.damage = removeExplode(damageFormulas.damage);
+        damageFormulas.raise = removeExplode(damageFormulas.raise);
     }
 
     const targets = await get_dmg_targets(target_token_id, br_card);

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -68,24 +68,17 @@ export function getAuthor(actor) {
 }
 
 export function makeExplodable(expression) {
-    // Make all dice of a roll able to explode
-    // Code from the SWADE system
-    const reg_exp = /\d*d\d+[^kdrxc]/g;
-    let new_expression = expression + " "; // Just because of my poor reg_exp foo
-    const dice_strings = new_expression.match(reg_exp);
-    const used = [];
-    if (dice_strings) {
-        dice_strings.forEach((match) => {
-            if (used.indexOf(match.slice(0, -1)) === -1) {
-                new_expression = new_expression.replace(
-                    new RegExp(match.slice(0, -1), "g"),
-                    match.slice(0, -1) + "x",
-                );
-                used.push(match.slice(0, -1));
-            }
-        });
-    }
-    return new_expression;
+    return expression.replace(
+        /(?:\d+)?d\d+/g,
+        (match, offset, string) => {
+            const next = string[offset + match.length];
+
+            // Already has a dice modifier.
+            if (next && /[kdrxc]/.test(next)) return match;
+
+            return `${match}x`;
+        }
+    );
 }
 
 export async function spendMastersBenny() {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -69,15 +69,10 @@ export function getAuthor(actor) {
 
 export function makeExplodable(expression) {
     return expression.replace(
-        /(?:\d+)?d\d+/g,
-        (match, offset, string) => {
-            const next = string[offset + match.length];
-
-            // Already has a dice modifier.
-            if (next && /[kdrxc]/.test(next)) return match;
-
-            return `${match}x`;
-        }
+        /((?:\d+)?d\d+)([a-zA-Z]+(?:[<>=]+-?\d+)*)?/g,
+        (match, dice, modifiers = "") => {
+            return modifiers ? match : `${dice}x`;
+        },
     );
 }
 

--- a/templates/item_card.hbs
+++ b/templates/item_card.hbs
@@ -83,30 +83,30 @@
         {{>"modules/betterrolls-swade2/templates/trait_roll_partial.hbs"}}
         {{>"modules/betterrolls-swade2/templates/trait_result_partial.hbs"}}
     {{/if}}
-    {{#if damage}}
-        <div class="brsw-form brsw-button-row brsw-form-options twbr:pt-2">
+    <div class="brsw-damage-section">
+        <div class="brsw-form brsw-button-row brsw-form-options twbr:pt-2" {{#unless damage}}hidden{{/unless}}>
             <span>
                 {{localize 'BRSW.Damage'}}
             </span>
             <span class="twbr:flex twbr:gap-1">
                 <button id="roll-damage" class="brsw-damage-button brsw-form twbr:py-0.5 twbr:px-5
-                     twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg
-                     twbr:border twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4
-                     twbr:focus:ring-gray-700 twbr:text-gray-800 twbr:border-gray-600
-                     twbr:hover:text-white twbr:hover:bg-gray-700" title="{{localize 'BRSW.Damage'}}">
+                         twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg
+                         twbr:border twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4
+                         twbr:focus:ring-gray-700 twbr:text-gray-800 twbr:border-gray-600
+                         twbr:hover:text-white twbr:hover:bg-gray-700" title="{{localize 'BRSW.Damage'}}">
                     <i class="fas fa-dice"></i>
                 </button>
                 <button id="roll-raise-damage" class="brsw-damage-button brsw-form twbr:py-0.5 twbr:px-5
-                    twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg
-                    twbr:border twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4
-                    twbr:focus:ring-gray-700 twbr:text-gray-800 twbr:border-gray-600
-                    twbr:hover:text-white twbr:hover:bg-gray-700" title="{{localize 'BRSW.RaiseDamage'}}">
+                        twbr:font-medium twbr:focus:outline-hidden twbr:bg-white twbr:rounded-lg
+                        twbr:border twbr:border-solid twbr:focus:z-10 twbr:focus:ring-4
+                        twbr:focus:ring-gray-700 twbr:text-gray-800 twbr:border-gray-600
+                        twbr:hover:text-white twbr:hover:bg-gray-700" title="{{localize 'BRSW.RaiseDamage'}}">
                     <i class="fas fa-plus"></i><i class="fas fa-dice-six"></i>
                 </button>
             </span>
         </div>
         {{>"modules/betterrolls-swade2/templates/damage_partial.hbs"}}
-    {{/if}}
+    </div>
     {{#if swade_templates}}
         <div class="brsw-form">
             <h4 class="brsw-item-subheading">


### PR DESCRIPTION
## Summary by Sourcery

Adjust damage handling and visibility in item cards to rely on item and action damage presence, and improve damage formula processing for rolls.

New Features:
- Show the damage section in item cards only when the item has damage or a selected action provides damage.

Bug Fixes:
- Correct handling of damage formulas, including shotgun damage, damage types, and explode modifiers to avoid malformed expressions.
- Ensure items without base damage can still expose damage rolling when actions define damage overrides.
- Fix inconsistencies between SWADE generic action properties and Better Rolls specific damage and trait fields.

Enhancements:
- Simplify and modernize damage dice explode logic to be more robust.
- Rename and streamline damage-related helper functions for clarity and consistency.

Documentation:
- Add changelog entry for version 5.16.1 describing damage formula fixes and conditional damage section display.