### PR TITLE
Use the trait name as the roll label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+# Version 5.17.1
+* Fixed attribute traits
+* We now use the trait name as the die label in the roll results
+* Added some missing supported keys for world global actions
+
 # Version 5.17.0
 * Major refactor to the way we store and handle skills and attributes to make them more generic. I've tested as much as I can but expect some bugs.
 * If an item does not have a trait set, we will search through the valid actions and automatically select one of them that has a trait override, so long as it doesn't contain one of a list of disallowed properties. For example, a skill override action that contains "dmgOverride" or "rof" will not be automatically selected. This is to ensure that we don't auto-select an action that may have unexpected behaviour. You can of course still manually select these actions yourself.

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -159,7 +159,7 @@ export async function roll_attribute(brCard, expend_bennie) {
   await roll_trait(
     brCard,
     brCard.actor.system.attributes[brCard.attribute],
-    game.i18n.localize("BRSW.AbilityDie"),
+    game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[brCard.attribute]),
     extra_data,
   );
   // noinspection ES6MissingAwait

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -974,9 +974,11 @@ function set_wild_die_theme(wildDie) {
  */
 function createRollString(traitDie, rof, traitName) {
     const sides = traitDie.die.sides;
+    const flavor = traitName ? `[${traitName}]` : "";
     //Don't explode on a d1 otherwise it will explode infinitely
-    const die = `1d${sides}${sides !== 1 ? "x" : ""}[${traitName}]`;
-    return [die, ...Array.from({ length: rof - 1 }, () => die)].join("+");
+    const die = `1d${sides}${sides !== 1 ? "x" : ""}${flavor}`;
+    const count = Math.max(1, Number(rof) || 1);
+    return [die, ...Array.from({ length: count - 1 }, () => die)].join("+");
 }
 
 /**

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -967,49 +967,41 @@ function set_wild_die_theme(wildDie) {
 
 /**
  * Creates a roll string from a trait a number of dice
- * @param trait_dice
+ * @param traitDie
  * @param rof
+ * @param traitName
  * @return {string}
  */
-function create_roll_string(trait_dice, rof) {
-    let roll_string = `1d${trait_dice.die.sides}x`;
-    // @zk-sn: If roll is a 1d1x (example: Strength score of 1), change it to 1d1 to prevent exploding die recursion.  (Fix for #211)
-    if (roll_string === `1d1x`) {
-        roll_string = `1d1`;
-        for (let i = 0; i < rof - 1; i++) {
-            roll_string += `+1d${trait_dice.die.sides}`;
-        }
-    } else {
-        for (let i = 0; i < rof - 1; i++) {
-            roll_string += `+1d${trait_dice.die.sides}x`;
-        }
-    }
-    return roll_string;
+function createRollString(traitDie, rof, traitName) {
+    const sides = traitDie.die.sides;
+    //Don't explode on a d1 otherwise it will explode infinitely
+    const die = `1d${sides}${sides !== 1 ? "x" : ""}[${traitName}]`;
+    return [die, ...Array.from({ length: rof - 1 }, () => die)].join("+");
 }
 
 /**
  * Makes a roll trait
  * @param {BrCommonCard}brCard
- * @param trait_dice - An object representing a trait dice
- * @param dice_label - Label for the trait die
+ * @param traitDie - An object representing a trait die
+ * @param traitName - Label for the trait die
  * @param extra_data - Extra data to add to render options
  */
-export async function roll_trait(brCard, trait_dice, dice_label, extra_data) {
+export async function roll_trait(brCard, traitDie, traitName, extra_data) {
     const { actor } = brCard;
     const roll_options = { modifiers: [], rof: undefined };
 
     if (!brCard.trait_roll.is_rolled) {
-        await get_new_roll_options(brCard, extra_data, trait_dice, roll_options);
+        await get_new_roll_options(brCard, extra_data, traitDie, roll_options);
     } else {
         roll_options.modifiers = brCard.trait_roll.modifiers;
         roll_options.rof = brCard.trait_roll.rof;
         await get_reroll_options(brCard, extra_data);
     }
 
-    let roll_string = create_roll_string(trait_dice, roll_options.rof);
+    let rollString = createRollString(traitDie, roll_options.rof, traitName);
 
     // Wild Die
-    let wild_die_formula = `+1d${trait_dice["wild-die"].sides}x`;
+    let wild_die_formula = `+1d${traitDie["wild-die"].sides}x`;
     if (extra_data.hasOwnProperty("wildDieFormula")) {
         wild_die_formula = extra_data.wildDieFormula;
         if (wild_die_formula.charAt(0) !== "+") {
@@ -1018,7 +1010,7 @@ export async function roll_trait(brCard, trait_dice, dice_label, extra_data) {
     }
 
     if ((actor.isWildcard || extra_data.add_wild_die) && wild_die_formula) {
-        roll_string += wild_die_formula;
+        rollString += wild_die_formula;
         brCard.trait_roll.wild_die = true;
     } else {
         brCard.trait_roll.wild_die = false;
@@ -1038,7 +1030,7 @@ export async function roll_trait(brCard, trait_dice, dice_label, extra_data) {
 
     brCard.trait_roll.arcaneActivationOffset = extra_data.arcaneActivationOffset;
 
-    const roll = new Roll(roll_string);
+    const roll = new Roll(rollString);
     await roll.evaluate();
     await brCard.trait_roll.add_roll(roll);
     await roll_dice(brCard.message, brCard.trait_roll, roll);

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -309,7 +309,7 @@ async function roll_soak(brCard, use_bennie) {
     await roll_trait(
         brCard,
         brCard.actor.system.attributes.vigor,
-        game.i18n.localize("BRSW.SoakRoll"),
+        game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS.vigor),
         { modifiers: soak_modifiers },
     );
 

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -105,7 +105,7 @@ async function roll_incapacitation(brCard, spend_benny) {
     await roll_trait(
         brCard,
         brCard.actor.system.attributes.vigor,
-        game.i18n.localize("BRSW.IncapacitationRoll"),
+        game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS.vigor),
         {},
     );
     let result = 0;

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -979,7 +979,7 @@ export async function roll_item(brCard, html, expend_bennie, roll_damage) {
     await roll_trait(
         brCard,
         brCard.traitDie,
-        game.i18n.localize("BRSW.SkillDie"),
+        brCard.render_data.trait?.name,
         extra_data,
     );
 
@@ -1185,26 +1185,26 @@ async function roll_dmg_target(
     let last_string_term = "";
     for (const term of roll.terms) {
         if (term.hasOwnProperty("_faces")) {
-            const new_die = {
+            const newDie = {
                 faces: term._faces,
                 results: [],
                 extra_class: "",
             };
-            new_die.label = term.flavor
+            newDie.label = term.flavor
                 ? `${term.flavor.charAt(0).toUpperCase()}${term.flavor.slice(1)}`
                 : game.i18n.localize("SWADE.Dmg");
-            new_die.label += ` (d${term._faces})`;
+            newDie.label += ` (d${term._faces})`;
             for (const result of term.results) {
-                new_die.results.push(result.result);
+                newDie.results.push(result.result);
                 if (result.result >= term._faces) {
-                    new_die.extra_class = " brsw-blue-text";
+                    newDie.extra_class = " brsw-blue-text";
                     if (!current_damage_roll.brswroll.rolls[0].extra_class) {
                         current_damage_roll.brswroll.rolls[0].extra_class =
                             " brsw-blue-text";
                     }
                 }
             }
-            current_damage_roll.brswroll.dice.push(new_die);
+            current_damage_roll.brswroll.dice.push(newDie);
         } else {
             if (term.number) {
                 const modifier_value = parseInt(last_string_term + term.number);
@@ -1474,7 +1474,6 @@ export async function roll_dmg(
                     : `${match}${damageType}`,
         );
 
-        damageFormulas.damage = addDamageType(damageFormulas.damage, damageType);
         damageFormulas.raise = addDamageType(damageFormulas.raise, damageType);
     }
 
@@ -1601,19 +1600,19 @@ async function add_damage_dice(brCard, index) {
     await roll.evaluate();
     damage_rolls.rolls[0].result += roll.total;
     roll.terms.forEach((term) => {
-        const new_die = {
+        const newDie = {
             faces: term.faces,
             results: [],
             extra_class: "",
             label: game.i18n.localize("SWADE.Dmg"),
         };
         if (term.total > term.faces) {
-            new_die.extra_class = " brsw-blue-text";
+            newDie.extra_class = " brsw-blue-text";
         }
         term.results.forEach((result) => {
-            new_die.results.push(result.result);
+            newDie.results.push(result.result);
         });
-        damage_rolls.dice.push(new_die);
+        damage_rolls.dice.push(newDie);
     });
     render_data.damage_rolls[index].damageResult = calculate_damage_results(
         damage_rolls.rolls,

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -136,7 +136,7 @@ async function roll_unshaken(brCard, use_bennie) {
     await roll_trait(
       brCard,
       brCard.actor.system.attributes.spirit,
-      game.i18n.localize("BRSW.SpiritRoll"),
+      game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS.spirit),
       { modifiers: modifiers },
     );
     let result = 0;
@@ -274,7 +274,7 @@ async function roll_unstun(brCard) {
   await roll_trait(
     brCard,
     brCard.actor.system.attributes.vigor,
-    game.i18n.localize("BRSW.VigorRoll"),
+    game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS.vigor),
     extra_options,
   );
   let result = 0;

--- a/scripts/rolls.js
+++ b/scripts/rolls.js
@@ -91,14 +91,15 @@ class SingleRoll {
   add_roll(roll, wild_die, modifiers) {
     roll.terms.forEach((term) => {
       if (term.hasOwnProperty("_faces")) {
-        let new_die = new Die(null);
+        let newDie = new Die(null);
         if (term.total === 1) {
-          new_die.extra_class = " brsw-red-text";
+          newDie.extra_class = " brsw-red-text";
         }
-        new_die.sides = term.faces;
-        new_die.raw_total = term.total;
-        new_die.modifiers = modifiers;
-        this.dice.push(new_die);
+        newDie.sides = term.faces;
+        newDie.raw_total = term.total;
+        newDie.modifiers = modifiers;
+        newDie.label = term.flavor ?? newDie.label;
+        this.dice.push(newDie);
       }
     });
     if (wild_die) {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -195,7 +195,7 @@ export async function roll_skill(brCard, expend_bennie) {
     await roll_trait(
         brCard,
         brCard.skill.system,
-        game.i18n.localize("BRSW.SkillDie"),
+        brCard.skill.name,
         extra_data,
     );
     await runMacros(macros, brCard);


### PR DESCRIPTION
## Summary by Sourcery

Label trait and skill rolls with their specific names and propagate these labels into the dice roll display while performing minor cleanup to roll and damage handling.

New Features:
- Include the trait or skill name as the label on trait dice in roll formulas and displayed dice results.

Bug Fixes:
- Prevent infinite exploding behavior on d1 trait dice while preserving rate-of-fire handling.

Enhancements:
- Refine roll trait API to pass explicit trait names instead of generic labels from all card types.
- Preserve roll term flavor as the die label when constructing SingleRoll dice for display.
- Align attribute-related roll labels with centralized attribute translation keys.
- Simplify and modernize roll and damage helper code with clearer naming and formula handling.