### PR TITLE
Popout tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Version 5.19.0
+* Improved chat popout handling
+* We now only show a chat notification if when not creating a popout. This cleans up the behaviour where you get both a popout and the chat notification when the sidebar is collapsed
+* Fixed the injury effect icon
+* Fixed injury rolls
+
 # Version 5.18.0
 * Improved range calculation and display
 * Fixed attributes in non-English languages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # Version 5.19.0
 * Improved chat popout handling
-* We now only show a chat notification if when not creating a popout. This cleans up the behaviour where you get both a popout and the chat notification when the sidebar is collapsed
+* We now only show a chat notification when not creating a popout. This cleans up the behaviour where you get both a popout and the chat notification when the sidebar is collapsed
 * Fixed the injury effect icon
 * Fixed injury rolls
 

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -9,6 +9,7 @@ import { calc_pp_cost } from "./item_card.js";
 import { get_actions, process_action } from "./global_actions.js";
 import { brAction } from "./actions.js";
 import { are_bennies_available, trait_to_string } from "./cards_common.js";
+import { BRSW2_CONST } from "./brsw2-const.js";
 
 /**
  * Stores a flag with the render data, deletes data can't be stored
@@ -53,7 +54,7 @@ export class BrCommonCard {
         this.update_list = {}; // List of properties pending to be updated
         this.resist_buttons = [];
         this.trait_roll = new TraitRoll();
-        this.popoutShown = false;
+        this.showPopout = true;
         this.manual_mods = {};
         this.applicable_effects = [];
         this.pp_modifiers = {};
@@ -69,33 +70,29 @@ export class BrCommonCard {
         }
     }
 
+    compileMessageFlags() {
+        const messageFlags = this.message?.flags["betterrolls-swade2"] || {};
+        messageFlags.br_data = JSON.parse(JSON.stringify(this.get_data()));
+        store_render_flag(messageFlags, this.render_data);
+        return messageFlags;
+    }
+
     async save() {
         if (!this.message) {
             await this.render();
         }
         const { update_list } = this;
         update_list.id = this.message.id;
-        update_list.flags = this.message.flags;
-        const br_flags = this.message.flags["betterrolls-swade2"] || {};
-        br_flags.br_data = JSON.parse(JSON.stringify(this.get_data()));
-        // Temporary
-        store_render_flag(br_flags, this.render_data);
-        update_list.flags["betterrolls-swade2"] = br_flags;
+        update_list.flags ??= {};
+        update_list.flags = {
+            ...update_list.flags,
+            "betterrolls-swade2": this.compileMessageFlags(),
+        };
         await this.message.update(update_list);
         this.update_list = {};
     }
 
-    createPopout() {
-        if (game.user.id !== this.message.author.id || this.popoutShown) {
-            return;
-        }
-
-        if (SettingsUtils.getUserSetting(BRSW2_CONFIG.USER_SETTING_KEYS.autoPopoutChat)) {
-            this.showPopout();
-        }
-    }
-
-    showPopout() {
+    async createPopout() {
         const top = cascade_starting_left + game.brsw.cascade_count * cascade_left_increment;
         const left = cascade_starting_top + game.brsw.cascade_count * cascade_top_increment;
 
@@ -108,12 +105,6 @@ export class BrCommonCard {
             message: this.message,
             position: { top: top, left: left },
         }).render(true);
-
-        this.popoutShown = true;
-
-        this.save().catch(() => {
-            console.error("Error saving card data after popout rendering");
-        });
     }
 
     closePopout() {
@@ -144,7 +135,7 @@ export class BrCommonCard {
             trait_roll: this.trait_roll,
             resist_buttons: this.resist_buttons,
             damage: this.damage,
-            popoutShown: this.popoutShown,
+            showPopout: this.showPopout,
             manual_mods: this.manual_mods,
             applicable_effects: this.applicable_effects,
             pp_modifiers: this.pp_modifiers,
@@ -171,7 +162,7 @@ export class BrCommonCard {
             "macro_buttons",
             "resist_buttons",
             "damage",
-            "popoutShown",
+            "showPopout",
             "manual_mods",
             "applicable_effects",
             "pp_modifiers",
@@ -187,10 +178,6 @@ export class BrCommonCard {
                 "betterrolls-swade2",
                 "render_data",
             );
-        }
-        //Backwards compatibility so that we don't show a bunch of old popouts
-        if (data.popup_shown !== undefined) {
-            this.popoutShown = true;
         }
     }
 
@@ -911,44 +898,40 @@ export class BrCommonCard {
      * @returns {Promise<void>}
      */
     async render(stored_selections = {}) {
-        if (!Object.keys(this.action_sections).length) {
-            this.populateActions(stored_selections);
+        //Basic rolls are just dice rolls without any of our normal fancy features
+        if (!this.basicRoll) {
+            if (!Object.keys(this.action_sections).length) {
+                this.populateActions(stored_selections);
 
-            if (this.item) {
-                this.selectFallbackActions();
-                this.showActions = this.shouldShowActionsMenu();
+                if (this.item) {
+                    this.selectFallbackActions();
+                    this.showActions = this.shouldShowActionsMenu();
+                }
             }
+
+            if (this.item && this.macro_buttons.length === 0) {
+                this.populateMacroButtons();
+            }
+
+            this.setTraitUsingSkillOverride();
+            this.refreshDamageFromActions();
+
+            this.getTrait();
+
+            this.pp_cost = this.render_data.is_power ? calc_pp_cost(this) : 0;
         }
 
-        if (this.item && this.macro_buttons.length === 0) {
-            this.populateMacroButtons();
-        }
-
-        this.setTraitUsingSkillOverride();
-        this.refreshDamageFromActions();
-
-        this.getTrait();
-
-        this.pp_cost = this.render_data.is_power ? calc_pp_cost(this) : 0;
-        const new_content = await foundry.applications.handlebars.renderTemplate(
+        const newContent = await foundry.applications.handlebars.renderTemplate(
             this.render_data.template,
             this.getDataRender(),
         );
 
-        await foundry.applications.ux.TextEditor.implementation.enrichHTML(new_content);
+        await foundry.applications.ux.TextEditor.implementation.enrichHTML(newContent);
 
         if (this.message) {
-            this.update_list.content = new_content;
+            this.update_list.content = newContent;
         } else {
-            await this.createFoundryMessage(new_content);
-
-            //If auto-popout is disabled, mark our popout as shown so that we won't show a bunch of old popouts if it's later enabled
-            this.popoutShown = !SettingsUtils.getUserSetting(BRSW2_CONFIG.USER_SETTING_KEYS.autoPopoutChat);
-
-            if (!this.message.author.active) {
-                //If the author isn't connected, mark the popout as shown so that we don't pop it out when they connect
-                this.popoutShown = true;
-            }
+            await this.createFoundryMessage(newContent);
         }
     }
 
@@ -1051,26 +1034,28 @@ export class BrCommonCard {
     /**
      * Creates the Foundry message object
      */
-    async createFoundryMessage(new_content) {
-        const chatData = await this.createBasicChatData();
-        if (new_content) {
-            chatData.content = new_content;
-        }
-        this.message = await ChatMessage.create(chatData);
+    async createFoundryMessage(content) {
+        const chatData = await this.createBasicChatData(content);
+        this.message = await ChatMessage.create(chatData, { notify: false });
     }
 
     /**
      * Creates the basic chat data common to most cards
      * @return {Object} An object suitable to create a ChatMessage
      */
-    async createBasicChatData() {
+    async createBasicChatData(content) {
         const whisperData = getWhisperData();
+        const brFlags = this.compileMessageFlags();
+        brFlags.creator = game.user.id;
         const chatData = {
             author: getAuthor(this.actor),
-            content: "<p>Default content, likely an error in Better Rolls</p>",
+            content: content ?? "<p>Default content, likely an error in Better Rolls</p>",
             speaker: ChatMessage.getSpeaker({ actor: this.actor }),
             blind: whisperData.blind,
-            flags: { core: { canPopout: true } },
+            flags: {
+                core: { canPopout: true },
+                "betterrolls-swade2": brFlags,
+            },
         };
         if (whisperData.whisper) {
             chatData.whisper = whisperData.whisper;

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -139,6 +139,21 @@ function activateCardListeners(brCard, html, message) {
     }
 }
 
+Hooks.on("createChatMessage", (message, options, userId) => {
+    const brData = message.getFlag("betterrolls-swade2", "br_data");
+    if (brData) {
+        if (brData.showPopout) {
+            const relevantMessage = message.getFlag("betterrolls-swade2", "creator") === game.user.id || message.author.id === game.user.id;
+            if (relevantMessage && SettingsUtils.getUserSetting(BRSW2_CONFIG.USER_SETTING_KEYS.autoPopoutChat)) {
+                const brCard = new BrCommonCard(message);
+                brCard.createPopout();
+            } else {
+                ui.chat.notify(message, { newMessage: true });
+            }
+        }
+    }
+});
+
 Hooks.on("renderChatMessageHTML", (message, html, options) => {
     const brData = message.getFlag("betterrolls-swade2", "br_data");
     if (brData) {
@@ -173,10 +188,6 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
         if (damageSection) {
             //If we have damage, show the damage section
             damageSection.hidden = !brCard.damage;
-        }
-
-        if (Object.keys(message.apps).length < 1) { // Don't create a popout when rendering popouts
-            brCard.createPopout();
         }
 
         const headerTitle = html.querySelector(".brsw-header-title");

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -147,10 +147,10 @@ Hooks.on("createChatMessage", (message, options, userId) => {
             if (relevantMessage && SettingsUtils.getUserSetting(BRSW2_CONFIG.USER_SETTING_KEYS.autoPopoutChat)) {
                 const brCard = new BrCommonCard(message);
                 brCard.createPopout();
-            } else {
-                ui.chat.notify(message, { newMessage: true });
+                return;
             }
         }
+        ui.chat.notify(message, { newMessage: true });
     }
 });
 

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -1,7 +1,6 @@
 // Functions for the damage card
 /* global game, canvas, CONST, Token, CONFIG, Hooks, succ, console */
 import { BrCommonCard } from "./BrCommonCard.js";
-import { WORLD_SETTING_KEYS } from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 import {
     are_bennies_available,
@@ -13,7 +12,7 @@ import {
     create_incapacitation_card,
     create_injury_card,
 } from "./incapacitation_card.js";
-import { SettingsUtils, Utils, addEventListenerAll } from "./utils.js";
+import { Utils, addEventListenerAll } from "./utils.js";
 
 /**
  * Shows a damage card and applies damage to the token/actor
@@ -67,9 +66,9 @@ export async function create_damage_card(
         },
         "modules/betterrolls-swade2/templates/damage_card.hbs",
     );
-    if (wounds === 0) {
+    if (damageResult.wounds === 0) {
         //If we're not dealing any wounds, don't bother popping out the card since there's no action required
-        brCard.popoutShown = true;
+        brCard.showPopout = false;
     }
     brCard.update_list = { ...brCard.update_list, ...{ user: user.id } };
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_DMG_CARD;
@@ -107,7 +106,7 @@ export function get_owner(actor) {
  */
 async function apply_damage(token_or_token_id, wounds, soaked = 0) {
     if (wounds < 0) {
-        return ("", false);
+        return { text: "", incapacitated: false, wounds: 0 };
     }
     const token =
         token_or_token_id instanceof foundry.canvas.placeables.Token
@@ -118,7 +117,7 @@ async function apply_damage(token_or_token_id, wounds, soaked = 0) {
     // noinspection JSUnresolvedVariable
     const initial_shaken = token.actor.system.status.isShaken;
     // We test for double shaken
-    let damage_wounds = wounds;
+    let damageWounds = wounds;
     let final_shaken = true; // Any damage also shakes the token
     let text = "";
     if (wounds < 1 && initial_shaken) {
@@ -133,9 +132,9 @@ async function apply_damage(token_or_token_id, wounds, soaked = 0) {
         });
         if (has_hardy || token.actor.getFlag("swade", "hardy")) {
             text += game.i18n.localize("BRSW.HardyActivated");
-            damage_wounds = 0;
+            damageWounds = 0;
         } else {
-            damage_wounds = 1;
+            damageWounds = 1;
         }
     }
     text += wounds
@@ -143,15 +142,15 @@ async function apply_damage(token_or_token_id, wounds, soaked = 0) {
             token_name: token.name,
             wounds: wounds,
         })
-        : damage_wounds
+        : damageWounds
             ? game.i18n.format("BRSW.DoubleShaken", { token_name: token.name })
             : game.i18n.format("BRSW.TokenShaken", { token_name: token.name });
     // Now we look for soaking
     if (soaked) {
-        damage_wounds -= soaked;
-        if (damage_wounds <= 0) {
+        damageWounds -= soaked;
+        if (damageWounds <= 0) {
             // All damage soaked, remove shaken
-            damage_wounds = 0;
+            damageWounds = 0;
             final_shaken = false;
             text += game.i18n.localize("BRSW.AllSoaked");
         } else {
@@ -159,7 +158,7 @@ async function apply_damage(token_or_token_id, wounds, soaked = 0) {
         }
     }
     // Final damage
-    let final_wounds = initial_wounds + damage_wounds;
+    let final_wounds = initial_wounds + damageWounds;
     const incapacitated = final_wounds > token.actor.system.wounds.max;
     const downed_condition = token.actor.isWildcard ? "incapacitated" : "dead";
     if (incapacitated) {
@@ -189,7 +188,7 @@ async function apply_damage(token_or_token_id, wounds, soaked = 0) {
         initial_shaken,
         soaked,
     );
-    return { text: text, incapacitated: incapacitated };
+    return { text, incapacitated, wounds: damageWounds };
 }
 
 /**

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -87,9 +87,7 @@ export function activate_incapacitation_card_listeners(message, html) {
         create_injury_card(
             brCard.token_id,
             ev.currentTarget.dataset.injuryType,
-        ).catch(() => {
-            console.error("Error creating injury card");
-        });
+        );
     });
 }
 
@@ -214,7 +212,8 @@ export async function create_injury_card(token_id, reason) {
     );
     brCard.update_list = { ...brCard.update_list, ...{ user: user.id } };
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_INJ_CARD;
-    brCard.popoutShown = true; //The injury result has no action, so we don't show the popout
+    brCard.basicRoll = true;
+    brCard.showPopout = false; //The injury result has no action, so we don't show the popout
     await brCard.render();
     await brCard.save();
     Hooks.call("BRSW-InjuryAEApplied", brCard, injury_effect, reason);
@@ -265,7 +264,7 @@ export async function create_injury_effect(actor, reason, first_result, second_r
                     ? "BRSW.TempInjuryName"
                     : "BRSW.TempInjury24Name";
         new_effect.name += game.i18n.localize(injury_duration_name);
-        new_effect.icon = "/systems/swade/assets/icons/skills/medical-pack.svg";
+        new_effect.img = "/systems/swade/assets/icons/skills/medical-pack.svg";
         injury_effect = await actor.createEmbeddedDocuments("ActiveEffect", [
             new_effect,
         ]);


### PR DESCRIPTION
## Summary by Sourcery

Adjust chat popout behavior and message flag handling for Better Rolls cards, refine damage/injury card behavior, and update user-facing changelog.

New Features:
- Add creator tracking and popout control via betterrolls-swade2 chat message flags to drive auto-popout behavior.

Bug Fixes:
- Prevent unnecessary popouts and duplicate notifications when the chat sidebar is collapsed by only popping out or notifying as appropriate.
- Ensure injury result and damage cards do not auto-popout when no user action is required.
- Fix injury rolls and injury ActiveEffect icon path to use the correct image property and asset.
- Correct damage application return values to include final wound count for downstream consumers.

Enhancements:
- Refactor common card message flag compilation and chat message creation to centralize br_data handling and disable default chat notifications for Better Rolls messages.
- Simplify rendering logic for basic rolls versus full-featured cards to avoid unnecessary calculations when not needed.

Documentation:
- Add changelog entry for version 5.19.0 describing popout improvements and injury-related fixes.