### PR TITLE
Fixes

### DIFF
--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -8,7 +8,7 @@ import { broofa, getAuthor, getWhisperData, SettingsUtils, Utils } from "./utils
 import { calc_pp_cost } from "./item_card.js";
 import { get_actions, process_action } from "./global_actions.js";
 import { brAction } from "./actions.js";
-import { are_bennies_available, trait_to_string } from "./cards_common.js";
+import { are_bennies_available, dieToString } from "./cards_common.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 
 /**
@@ -862,7 +862,7 @@ export class BrCommonCard {
 
             this.render_data.trait = trait;
             this.render_data.traitTitle = trait
-                ? trait.name + " " + trait_to_string(trait.system)
+                ? (trait.translatedName ?? trait.name) + " " + dieToString(trait.system)
                 : "";
         }
     }

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -8,7 +8,7 @@ import { broofa, getAuthor, getWhisperData, SettingsUtils, Utils } from "./utils
 import { calc_pp_cost } from "./item_card.js";
 import { get_actions, process_action } from "./global_actions.js";
 import { brAction } from "./actions.js";
-import { are_bennies_available, dieToString } from "./cards_common.js";
+import { are_bennies_available, traitToDieString } from "./cards_common.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 
 /**
@@ -862,7 +862,7 @@ export class BrCommonCard {
 
             this.render_data.trait = trait;
             this.render_data.traitTitle = trait
-                ? (trait.translatedName ?? trait.name) + " " + dieToString(trait.system)
+                ? (trait.translatedName ?? trait.name) + " " + traitToDieString(trait.system)
                 : "";
         }
     }

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -10,7 +10,7 @@ import {
   process_common_actions,
   roll_trait,
   spend_bennie,
-  trait_to_string,
+  dieToString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
@@ -33,7 +33,7 @@ async function create_attribute_card(origin, name, { actions_stored = {} } = {},
   }
 
   const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
-  const title = translatedName + " " + trait_to_string(actor.system.attributes[name.toLowerCase()]);
+  const title = translatedName + " " + dieToString(actor.system.attributes[name.toLowerCase()]);
 
   const brCard = create_common_card(
     origin,

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -10,7 +10,7 @@ import {
   process_common_actions,
   roll_trait,
   spend_bennie,
-  dieToString,
+  traitToDieString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
@@ -33,7 +33,7 @@ async function create_attribute_card(origin, name, { actions_stored = {} } = {},
   }
 
   const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
-  const title = translatedName + " " + dieToString(actor.system.attributes[name.toLowerCase()]);
+  const title = translatedName + " " + traitToDieString(actor.system.attributes[name.toLowerCase()]);
 
   const brCard = create_common_card(
     origin,

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -539,7 +539,7 @@ export function get_roll_options(old_options, brCard) {
  * Function to convert trait dice and modifiers into a string
  * @param trait
  */
-export function dieToString(trait) {
+export function traitToDieString(trait) {
     const { sides, modifier } = trait.die;
     const mod = Number(modifier);
     return `d${sides}${mod ? (mod > 0 ? "+" : "") + mod : ""}`;

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -539,13 +539,10 @@ export function get_roll_options(old_options, brCard) {
  * Function to convert trait dice and modifiers into a string
  * @param trait
  */
-export function trait_to_string(trait) {
-    let string = `d${trait.die.sides}`;
-    const modifier = parseInt(trait.die.modifier);
-    if (modifier) {
-        string = string + (modifier > 0 ? "+" : "") + modifier;
-    }
-    return string;
+export function dieToString(trait) {
+    const { sides, modifier } = trait.die;
+    const mod = Number(modifier);
+    return `d${sides}${mod ? (mod > 0 ? "+" : "") + mod : ""}`;
 }
 
 export async function detect_fumble(has_wild_die, num_fumble_results, dice) {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -11,7 +11,7 @@ import {
     process_common_actions,
     roll_trait,
     spend_bennie,
-    dieToString,
+    traitToDieString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { TraitModifier } from "./modifiers.js";
@@ -47,7 +47,7 @@ async function create_skill_card(
         actor = origin;
     }
     const skill = actor.items.get(skillId);
-    const extra_name = skill.name + " " + dieToString(skill.system);
+    const extra_name = skill.name + " " + traitToDieString(skill.system);
     const brCard = create_common_card(
         origin,
         {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -11,7 +11,7 @@ import {
     process_common_actions,
     roll_trait,
     spend_bennie,
-    trait_to_string,
+    dieToString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { TraitModifier } from "./modifiers.js";
@@ -47,7 +47,7 @@ async function create_skill_card(
         actor = origin;
     }
     const skill = actor.items.get(skillId);
-    const extra_name = skill.name + " " + trait_to_string(skill.system);
+    const extra_name = skill.name + " " + dieToString(skill.system);
     const brCard = create_common_card(
         origin,
         {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -394,9 +394,10 @@ export class Utils {
             // Time to check for an attribute
             for (const attribute of BRSW2_CONST.ATTRIBUTES) {
                 const translation = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[attribute]);
-                if (traitLower === translation.toLowerCase()) {
+                if (traitLower === attribute || traitLower === translation.toLowerCase()) {
                     trait = { system: structuredClone(actor.system.attributes[attribute]) };
                     trait.name = attribute;
+                    trait.translatedName = translation;
                     break;
                 }
             }


### PR DESCRIPTION
## Summary by Sourcery

Standardize trait die string formatting and improve trait name localization handling across cards.

Enhancements:
- Replace trait_to_string with dieToString helper for consistent die string formatting using numeric modifiers.
- Display translated trait names when available on common, attribute, and skill cards.
- Allow trait lookup by both attribute key and its localized name while preserving the localized label on the resolved trait.