### PR TITLE
Token refactoring

### DIFF
--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -36,7 +36,7 @@ game.brsw.add_actions(actions)
 You can learn more about this at: [GLOBAL ACTIONS API](https://github.com/ddbrown30/betteroll-swade/wiki/Global-Actions#api).
 
 ```js
-game.brsw.create_attribute_card()
+game.brsw.createAttributeCard()
 /**
  * Creates a chat card for an attribute
  *

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -24,13 +24,8 @@ import { Utils, addEventListenerAll } from "./utils.js";
  *   and a boolean meaning if they need to set on or off
  * @return {Promise} A promise for the BrCommonCard object
  */
-async function create_attribute_card(origin, name, { actions_stored = {} } = {},) {
-  let actor;
-  if (origin instanceof TokenDocument || origin instanceof foundry.canvas.placeables.Token) {
-    actor = origin.actor;
-  } else {
-    actor = origin;
-  }
+async function createAttributeCard(origin, name, { actions_stored = {} } = {},) {
+  const actor = Utils.toActor(origin);
 
   const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
   const title = translatedName + " " + traitToDieString(actor.system.attributes[name.toLowerCase()]);
@@ -70,7 +65,7 @@ function create_attribute_card_from_id(
   { actions_stored = {} } = {},
 ) {
   const actor = get_actor_from_ids(token_id, actor_id);
-  return create_attribute_card(actor, name, {
+  return createAttributeCard(actor, name, {
     actions_stored: actions_stored,
   });
 }
@@ -79,7 +74,14 @@ function create_attribute_card_from_id(
  * Hooks the public functions to a global object
  */
 export function attribute_card_hooks() {
-  game.brsw.create_atribute_card = create_attribute_card;
+  game.brsw.create_atribute_card = (...args) => {
+    foundry.utils.logCompatibilityWarning(
+      "game.brsw.create_atribute_card is deprecated. Use game.brsw.createAttributeCard instead.",
+      { since: "5.19.0" }
+    );
+    return createAttributeCard(...args);
+  };
+  game.brsw.createAttributeCard = createAttributeCard;
   game.brsw.create_attribute_card_from_id = create_attribute_card_from_id;
   game.brsw.roll_attribute = roll_attribute;
 }
@@ -100,7 +102,7 @@ async function attribute_click_listener(ev, target) {
   // The attribute id placement is sheet dependent.
   const attribute_id = ev.currentTarget.dataset.attribute;
   // Show card
-  const brCard = await create_attribute_card(target, attribute_id);
+  const brCard = await createAttributeCard(target, attribute_id);
   if (action.includes("dialog")) {
     game.brsw.dialog.show_card(brCard);
   } else if (action.includes("trait")) {

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -288,7 +288,7 @@ function create_attribute_macro(data) {
       game.swade.rollItemMacro("${data.attribute}");
     } else {
       origin = await fromUuid("${data.uuid}");
-      const brCard = await game.brsw.create_atribute_card(origin, "${data.attribute}");
+      const brCard = await game.brsw.createAttributeCard(origin, "${data.attribute}");
       if (behaviour.includes('trait')) {
         game.brsw.roll_attribute(brCard, false);
       }

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -21,7 +21,7 @@ import {
 } from "./remove_status_cards.js";
 import { TraitRoll } from "./rolls.js";
 import {
-    calculate_distance,
+    calculateDistance,
     getTNFromToken,
     roll_skill,
 } from "./skill_card.js";
@@ -29,7 +29,8 @@ import {
     SettingsUtils,
     Utils,
     addEventListenerAll,
-    get_targeted_token,
+    getSelectedToken,
+    getTargetedToken,
     set_or_update_condition,
     simple_form,
     spendMastersBenny,
@@ -68,12 +69,7 @@ export function expose_card_class() {
  * @returns {BrCommonCard} The created common card.
  */
 export function create_common_card(origin, render_data, template) {
-    let actor;
-    if (origin instanceof TokenDocument || origin instanceof foundry.canvas.placeables.Token) {
-        actor = origin.actor;
-    } else {
-        actor = origin;
-    }
+    const actor = Utils.toActor(origin);
 
     if (render_data.tooltip) {
         render_data.tooltip = // Limit tooltip size.
@@ -349,14 +345,7 @@ export function activate_common_listeners(brCard, html) {
     // TNs from target
     addEventListenerAll(html, ".brsw-target-tn, .brsw-selected-tn", "click", (ev) => {
         ev.stopPropagation();
-        const { index } = ev.currentTarget.dataset;
-        get_tn_from_target(
-            brCard,
-            parseInt(index),
-            ev.currentTarget.classList.contains("brsw-selected-tn"),
-        ).catch((e) => {
-            console.error("ERROR getting_tn_from_target. Error:" + e);
-        });
+        getTNFromTarget(brCard, ev.currentTarget.classList.contains("brsw-selected-tn"));
     });
     // Repeat card
     html.querySelector(".brsw-repeat-card")?.addEventListener("click", (ev) => {
@@ -715,100 +704,88 @@ function get_actor_own_modifiers(actor, roll_options) {
 /**
  * Get all the options needed for a new roll
  * @param {BrCommonCard} brCard
- * @param extra_data
- * @param trait_dice
- * @param roll_options - An object with the current roll_options
+ * @param extraData
+ * @param traitDice
+ * @param rollOptions - An object with the current roll_options
  */
-async function get_new_roll_options(
+async function getNewRollOptions(
     brCard,
-    extra_data,
-    trait_dice,
-    roll_options,
+    extraData,
+    traitDice,
+    rollOptions,
 ) {
-    const extra_options = {};
+    const extraOptions = {};
 
-    let targetToken = get_targeted_token();
-    if (!targetToken) {
-        canvas.tokens.controlled.forEach((token) => {
-            // noinspection JSUnresolvedVariable
-            if (
-                token.actor !== brCard.actor &&
-                token.actor !== brCard.vehicle_actor
-            ) {
-                targetToken = token;
-            }
-        });
-    }
-
+    const targetToken = getTargetedToken([brCard.actor, brCard.vehicle_actor].filter(Boolean));
     if (targetToken) {
-        const origin_token = brCard.token;
-        const target_data = await getTNFromToken(
+        const originToken = brCard.token;
+        const targetData = await getTNFromToken(
             brCard.skill,
             targetToken,
-            origin_token,
+            originToken,
             brCard.actor,
             brCard.item,
-            extra_data,
+            extraData,
         );
-        brCard.trait_roll.tn = target_data.value;
-        brCard.trait_roll.tn_reason = target_data.reason;
-        extra_options.target_modifiers = target_data.modifiers;
+        brCard.trait_roll.tn = targetData.value;
+        brCard.trait_roll.tn_reason = targetData.reason;
+        extraOptions.target_modifiers = targetData.modifiers;
     }
 
-    if (extra_data.hasOwnProperty("tn")) {
-        extra_options.tn = extra_data.tn;
-        extra_options.tn_reason = extra_data.tn_reason.slice(0, 20);
+    if (extraData.hasOwnProperty("tn")) {
+        extraOptions.tn = extraData.tn;
+        extraOptions.tn_reason = extraData.tn_reason.slice(0, 20);
     }
 
-    if (extra_data.hasOwnProperty("rof")) {
-        extra_options.rof = extra_data.rof;
+    if (extraData.hasOwnProperty("rof")) {
+        extraOptions.rof = extraData.rof;
     }
 
-    const options = get_roll_options(extra_options, brCard);
-    roll_options.rof = options.rof || 1;
+    const options = get_roll_options(extraOptions, brCard);
+    rollOptions.rof = options.rof || 1;
 
     // Trait modifier
-    if (parseInt(trait_dice.die.modifier)) {
-        const mod_value = parseInt(trait_dice.die.modifier);
-        roll_options.modifiers.push(
+    if (parseInt(traitDice.die.modifier)) {
+        const mod_value = parseInt(traitDice.die.modifier);
+        rollOptions.modifiers.push(
             new TraitModifier(game.i18n.localize("BRSW.TraitMod"), mod_value),
         );
     }
 
-    get_below_chat_modifiers(options, roll_options);
-    get_actor_own_modifiers(brCard.actor, roll_options);
+    get_below_chat_modifiers(options, rollOptions);
+    get_actor_own_modifiers(brCard.actor, rollOptions);
 
     // Armor min str
     if (brCard.skill?.system.attribute === "agility" || brCard.attribute === "agility") {
         const armor_penalty = get_actor_armor_minimum_strength(brCard.actor);
         if (armor_penalty) {
-            roll_options.modifiers.push(armor_penalty);
+            rollOptions.modifiers.push(armor_penalty);
         }
     }
 
     // Target Mods
-    if (extra_options.target_modifiers) {
-        extra_options.target_modifiers.forEach((modifier) => {
-            roll_options.modifiers.push(modifier);
+    if (extraOptions.target_modifiers) {
+        extraOptions.target_modifiers.forEach((modifier) => {
+            rollOptions.modifiers.push(modifier);
         });
     }
 
     // Options set from card
-    if (extra_data.modifiers) {
-        extra_data.modifiers.forEach((modifier) => {
-            roll_options.modifiers.push(modifier);
+    if (extraData.modifiers) {
+        extraData.modifiers.forEach((modifier) => {
+            rollOptions.modifiers.push(modifier);
         });
     }
 
     //Conviction
     const conviction_modifier = await check_and_roll_conviction(brCard.actor);
     if (conviction_modifier) {
-        roll_options.modifiers.push(conviction_modifier);
+        rollOptions.modifiers.push(conviction_modifier);
     }
 
     // Joker
     if (brCard.token && has_joker(brCard.token.id)) {
-        roll_options.modifiers.push(
+        rollOptions.modifiers.push(
             new TraitModifier(
                 "Joker",
                 brCard.actor.getFlag("swade", "jokerBonus") ?? 2,
@@ -821,7 +798,7 @@ async function get_new_roll_options(
     if ((brCard.actor.type === "character" || npcsUseEncumbrance) &&
         brCard.actor.system.encumbered &&
         (brCard.attribute === "agility" || brCard.skill?.system.attribute === "agility")) {
-        roll_options.modifiers.push(new TraitModifier(game.i18n.localize("SWADE.Encumbered"), -2),);
+        rollOptions.modifiers.push(new TraitModifier(game.i18n.localize("SWADE.Encumbered"), -2),);
     }
 
     // Vehicle
@@ -834,7 +811,7 @@ async function get_new_roll_options(
         );
         handling = Math.max(handling, -4); //Handling cannot be lower than -4
         if (handling !== 0) {
-            roll_options.modifiers.push(new TraitModifier("Handling", handling));
+            rollOptions.modifiers.push(new TraitModifier("Handling", handling));
         }
     }
 }
@@ -990,7 +967,7 @@ export async function roll_trait(brCard, traitDie, traitName, extra_data) {
     const roll_options = { modifiers: [], rof: undefined };
 
     if (!brCard.trait_roll.is_rolled) {
-        await get_new_roll_options(brCard, extra_data, traitDie, roll_options);
+        await getNewRollOptions(brCard, extra_data, traitDie, roll_options);
     } else {
         roll_options.modifiers = brCard.trait_roll.modifiers;
         roll_options.rof = brCard.trait_roll.rof;
@@ -1175,50 +1152,43 @@ async function edit_tn(brCard, new_tn, reason) {
  * Change the TNs of a roll from a token (targeted or selected)
  *
  * @param {BrCommonCard} brCard
- * @param {int} index
  * @param {boolean} selected - True to select targeted, false for selected
  */
-async function get_tn_from_target(brCard, index, selected) {
-    let targetToken;
-    if (selected) {
-        canvas.tokens.controlled.forEach((token) => {
-            // noinspection JSUnresolvedVariable
-            if (token.actor !== brCard.actor) {
-                targetToken = token;
-            }
-        });
-    } else {
-        targetToken = get_targeted_token();
-    }
+async function getTNFromTarget(brCard, selected) {
+    const targetToken = selected ? getSelectedToken([brCard.actor]) : getTargetedToken([brCard.actor]);
     if (targetToken) {
         const extra_data = { modifiers: [] };
-        const origin_token = brCard.token;
+        const originToken = brCard.token;
         const target = await getTNFromToken(
             brCard.skill,
             targetToken,
-            origin_token,
+            originToken,
             brCard.actor,
             brCard.item,
             extra_data,
         );
+
         if (target.value) {
             await edit_tn(brCard, target.value, target.reason).catch(() => {
                 console.error("Error editing TN");
             });
         }
+
         const tn = { modifiers: [] };
-        calculate_distance(
-            origin_token,
+        calculateDistance(
+            originToken,
             targetToken,
             brCard.item,
             tn,
             brCard.skill,
             extra_data,
         );
+
         brCard.trait_roll.delete_range_modifiers();
         brCard.trait_roll.modifiers = brCard.trait_roll.modifiers.concat(
             tn.modifiers,
         );
+
         await brCard.trait_roll.recalculate_trait_results();
         await brCard.render();
         await brCard.save();

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -32,7 +32,7 @@ import {
     addEventListenerAll,
     broofa,
     getAuthor,
-    get_targeted_token,
+    getTargetedToken,
     makeExplodable,
     set_or_update_condition,
     simple_form,
@@ -55,11 +55,7 @@ export async function create_item_card(
     item_id,
     { actions_stored = {} } = {},
 ) {
-    let actor = origin;
-    if (origin instanceof TokenDocument || origin instanceof foundry.canvas.placeables.Token) {
-        actor = origin.actor;
-    }
-
+    const actor = Utils.toActor(origin);
 
     let item = actor.items.find((item) => {
         return item.id === item_id;
@@ -355,13 +351,7 @@ async function item_click_listener(ev, target, currentTarget) {
     ev.stopImmediatePropagation();
     ev.preventDefault();
     ev.stopPropagation();
-    let actor =
-        target instanceof Actor
-            ? target
-            : target instanceof foundry.canvas.placeables.Token ||
-                target instanceof TokenDocument
-                ? target.actor
-                : null;
+    const actor = Utils.toActor(origin);
     const item_action = ev.currentTarget.dataset.action;
     const item_id = ev.target.closest("[data-item-id]").dataset.itemId;
     const item = actor.items.find((item) => {
@@ -611,21 +601,15 @@ async function roll_resist(trait, brCard, trait_mod) {
         return;
     }
     for (const token of canvas.tokens.controlled) {
-        const trait_lower = trait.toLowerCase();
-        let new_card;
-        if (BRSW2_CONST.ATTRIBUTES.includes(trait_lower)) {
-            new_card = await game.brsw.create_atribute_card(
-                token,
-                trait.toLowerCase(),
-            );
+        let newCard;
+        if (BRSW2_CONST.ATTRIBUTES.includes(trait.toLowerCase())) {
+            newCard = await game.brsw.createAttributeCard(token, trait.toLowerCase());
         } else {
-            new_card = await game.brsw.create_skill_card(
-                token,
-                Utils.traitFromString(token.actor, trait).id,
-            );
+            newCard = await game.brsw.create_skill_card(token, Utils.traitFromString(token.actor, trait).id);
         }
-        new_card.trait_roll.tn = get_trait_roll_difficulty(brCard);
-        new_card.trait_roll.tn_reason = game.i18n.localize("BRSW.ResistingRoll");
+
+        newCard.trait_roll.tn = getTraitRollDifficulty(brCard);
+        newCard.trait_roll.tn_reason = game.i18n.localize("BRSW.ResistingRoll");
         if (!isNaN(trait_mod)) {
             const localized_name = game.i18n.localize("BRSW.ResistingRoll");
             const resist_action = new brAction(localized_name, {
@@ -633,8 +617,9 @@ async function roll_resist(trait, brCard, trait_mod) {
                 button_name: localized_name,
                 skillMod: trait_mod,
             });
+
             resist_action.selected = true;
-            new_card.action_sections["none"].action_groups.resist_button = {
+            newCard.action_sections["none"].action_groups.resist_button = {
                 defaultChecked: "on",
                 name: localized_name,
                 id: broofa(),
@@ -642,8 +627,8 @@ async function roll_resist(trait, brCard, trait_mod) {
                 actions: [resist_action],
             };
         }
-        await new_card.render();
-        await new_card.save();
+        await newCard.render();
+        await newCard.save();
     }
 }
 
@@ -653,7 +638,7 @@ async function roll_resist(trait, brCard, trait_mod) {
  * @param {Object} brCard - The card object containing trait roll information.
  * @return {number} - The calculated difficulty of the trait roll.
  */
-function get_trait_roll_difficulty(brCard) {
+function getTraitRollDifficulty(brCard) {
     if (brCard.item && brCard.item.type === "power") {
         if (brCard.item.system.description.indexOf(game.i18n.localize("BRSW.Opposed")) === -1) {
             // If this is a power, and we can't find opposed in the description, it is probably a flat check.
@@ -1029,30 +1014,22 @@ export async function roll_item(brCard, html, expend_bennie, roll_damage) {
 // DAMAGE ROLLS
 /**
  * Gets the toughness value for the targeted token
- * @param {SwadeActor} acting_actor
+ * @param {SwadeActor} originActor
  * @param {Token} target
  * @param {string} location
  */
 function get_target_defense(
-    acting_actor,
+    originActor,
     target = undefined,
     location = "torso",
 ) {
-    let objective = target || get_targeted_token();
-    if (!objective) {
-        canvas.tokens.controlled.forEach((token) => {
-            // noinspection JSUnresolvedVariable
-            if (token.actor !== acting_actor) {
-                objective = token;
-            }
-        });
-    }
+    const objective = target || getTargetedToken([originActor]);
     const defense_values = {
         toughness: 4,
         armor: 0,
         name: game.i18n.localize("BRSW.Default"),
     };
-    if (objective && objective.actor) {
+    if (objective?.actor) {
         if (objective.actor.type !== "vehicle") {
             //Get the base toughness without armor
             const base_toughness =
@@ -1826,14 +1803,8 @@ async function execute_macro(action, brCard) {
         targetToken = game.user.targets.first() || brCard.token;
         targetActor = targetToken.actor;
     } else {
-        targetToken =
-            game.canvas.tokens.controlled.length < 1
-                ? brCard.token
-                : game.canvas.tokens.controlled[0];
-        targetActor =
-            game.canvas.tokens.controlled.length < 1
-                ? brCard.actor
-                : game.canvas.tokens.controlled[0].actor;
+        targetToken = game.canvas.tokens.controlled.length < 1 ? brCard.token : game.canvas.tokens.controlled[0];
+        targetActor = game.canvas.tokens.controlled.length < 1 ? brCard.actor : game.canvas.tokens.controlled[0].actor;
     }
     await macro.execute({
         actor: targetActor,

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -351,7 +351,7 @@ async function item_click_listener(ev, target, currentTarget) {
     ev.stopImmediatePropagation();
     ev.preventDefault();
     ev.stopPropagation();
-    const actor = Utils.toActor(origin);
+    const actor = Utils.toActor(target);
     const item_action = ev.currentTarget.dataset.action;
     const item_id = ev.target.closest("[data-item-id]").dataset.itemId;
     const item = actor.items.find((item) => {

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -37,15 +37,7 @@ async function create_skill_card(
     skillId,
     { actions_stored = {}, vehicle } = {},
 ) {
-    let actor;
-    if (
-        origin instanceof TokenDocument ||
-        origin instanceof foundry.canvas.placeables.Token
-    ) {
-        actor = origin.actor;
-    } else {
-        actor = origin;
-    }
+    const actor = Utils.toActor(origin);
     const skill = actor.items.get(skillId);
     const extra_name = skill.name + " " + traitToDieString(skill.system);
     const brCard = create_common_card(
@@ -64,10 +56,7 @@ async function create_skill_card(
     brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD;
     if (vehicle) {
         brCard.vehicle_actor_id = vehicle.actor?.id || vehicle.id;
-        if (
-            vehicle instanceof TokenDocument ||
-            vehicle instanceof foundry.canvas.placeables.Token
-        ) {
+        if (vehicle instanceof TokenDocument || vehicle instanceof foundry.canvas.placeables.Token) {
             brCard.vehicle_token_id = vehicle.id;
         }
     }
@@ -205,32 +194,32 @@ export async function roll_skill(brCard, expend_bennie) {
  * Calculates the distance modifier for normal weapons
  * @param item
  * @param distance
- * @param origin_token
+ * @param originToken
  * @param targetToken
  * @param skill
  * @param tn
  * @returns {number}
  */
-function calculate_generic_distance_modifier(
+function calculateGenericDistanceModifier(
     item,
     distance,
-    origin_token,
+    originToken,
     targetToken,
     skill,
     tn,
     extra_data,
 ) {
     const range = item.system.range.split("/");
-    if (origin_token.document.elevation !== targetToken.document.elevation) {
+    if (originToken.elevation !== targetToken.elevation) {
         const elevationDiff = Math.abs(
-            origin_token.document.elevation - targetToken.document.elevation,
+            originToken.elevation - targetToken.elevation,
         );
         distance = Math.sqrt(Math.pow(elevationDiff, 2) + Math.pow(distance, 2));
     }
 
     let rangeEffects = 0;
     if (Utils.isThrowingSkill(skill)) {
-        rangeEffects = origin_token.actor.appliedEffects
+        rangeEffects = originToken.actor.appliedEffects
             .filter(effect => !effect.disabled)
             .reduce((total, effect) => {
                 const change = effect.changes.find(ch => ch.key === "brsw.thrown-range-modifier");
@@ -270,29 +259,29 @@ function calculate_generic_distance_modifier(
 
 /**
  * Calculates the distance between tokens
- * @param origin_token
+ * @param originToken
  * @param targetToken
  * @param item
  * @param tn
  * @param {SwadeItem} skill
  * @return {boolean} True if parry should be used as the tn (tokens are adjacent)
  */
-export function calculate_distance(
-    origin_token,
+export function calculateDistance(
+    originToken,
     targetToken,
     item,
     tn,
     skill,
     extra_data,
 ) {
-    if (item.system.isVehicular && origin_token.actor.type !== "vehicle") {
+    if (item.system.isVehicular && originToken.actor.type !== "vehicle") {
         return false;
     }
     const grid_unit = canvas.grid.distance;
-    let use_parry_as_tn = false;
-    let distance = measureDistance(origin_token, targetToken);
+    let useParryAsTN = false;
+    let distance = measureDistance(originToken, targetToken);
     if (distance / grid_unit < 1 && item) {
-        use_parry_as_tn = item.type !== "power";
+        useParryAsTN = item.type !== "power";
     } else if (item) {
         if (grid_unit % 5 === 0) {
             distance /= 5;
@@ -302,10 +291,10 @@ export function calculate_distance(
                 ui.notifications.error(game.i18n.localize("BRSW.SpellOverRange"));
             }
         } else {
-            calculate_generic_distance_modifier(
+            calculateGenericDistanceModifier(
                 item,
                 distance,
-                origin_token,
+                originToken,
                 targetToken,
                 skill,
                 tn,
@@ -313,7 +302,7 @@ export function calculate_distance(
             );
         }
     }
-    return use_parry_as_tn;
+    return useParryAsTN;
 }
 
 /**
@@ -342,14 +331,14 @@ async function get_vehicle_tn(tn, targetToken) {
  *
  * @param {Item} skill
  * @param {Token} targetToken
- * @param {Token} origin_token
+ * @param {Token} originToken
  * @param {Item} item
  */
 export async function getTNFromToken(
     skill,
     targetToken,
-    origin_token,
-    origin_actor,
+    originToken,
+    originActor,
     item,
     extra_data,
 ) {
@@ -358,17 +347,21 @@ export async function getTNFromToken(
         value: 4,
         modifiers: [],
     };
-    const is_fighting = Utils.isFightingSkill(skill);
-    let use_parry_as_tn = is_fighting;
-    if (origin_token) {
-        if (is_fighting) {
-            const gangup = calculateGangUp(origin_token, targetToken);
-            if (gangup.bonus) {
-                tn.modifiers.push(new TraitModifier(gangup.name, gangup.bonus));
+
+    originToken = Utils.toTokenDoc(originToken);
+    targetToken = Utils.toTokenDoc(targetToken);
+
+    const isFighting = Utils.isFightingSkill(skill);
+    let useParryAsTN = isFighting;
+    if (originToken) {
+        if (isFighting) {
+            const gangUp = calculateGangUp(originToken, targetToken);
+            if (gangUp.bonus) {
+                tn.modifiers.push(new TraitModifier(gangUp.name, gangUp.bonus));
             }
         } else if (item && item.system.range) {
-            use_parry_as_tn = calculate_distance(
-                origin_token,
+            useParryAsTN = calculateDistance(
+                originToken,
                 targetToken,
                 item,
                 tn,
@@ -377,7 +370,7 @@ export async function getTNFromToken(
             );
         }
     }
-    if (use_parry_as_tn) {
+    if (useParryAsTN) {
         if (targetToken.actor.type !== "vehicle") {
             tn.reason = `${game.i18n.localize("SWADE.Parry")} - ${targetToken.name}`;
             tn.value = parseInt(targetToken.actor.system.stats.parry.value);
@@ -386,8 +379,8 @@ export async function getTNFromToken(
         }
     }
     // Size modifiers
-    if (shouldUseScale(origin_actor, targetToken, item, skill)) {
-        getScaleModifier(origin_actor, targetToken.actor, item, tn, extra_data);
+    if (shouldUseScale(originActor, targetToken, item, skill)) {
+        getScaleModifier(originActor, targetToken.actor, item, tn, extra_data);
     }
     if (
         targetToken.actor.system.status.isVulnerable ||
@@ -530,7 +523,7 @@ export function calculateGangUp(attackerToken, targetToken) {
         return 0;
     }
 
-    if (attackerToken.document.disposition * targetToken.document.disposition !== -1) {
+    if (attackerToken.disposition * targetToken.disposition !== -1) {
         return 0;
     }
 
@@ -553,8 +546,8 @@ export function calculateGangUp(attackerToken, targetToken) {
     //Get all the attacker allies that are next to the target
     const attackerAllies =
         scene.tokens?.filter((t) => {
-            if (t === attackerToken.document) return false;
-            if (t.disposition !== attackerToken.document.disposition) return false;
+            if (t === attackerToken) return false;
+            if (t.disposition !== attackerToken.disposition) return false;
             if (isIgnoredForGangUp(t)) return false;
             return withinRange(targetToken, t, meleeRange);
         });
@@ -582,8 +575,8 @@ export function calculateGangUp(attackerToken, targetToken) {
     //Get all the defender allies that are next to the target
     const defenderAllies =
         scene.tokens?.filter((t) => {
-            if (t === targetToken.document) return false;
-            if (t.disposition !== targetToken.document.disposition) return false;
+            if (t === targetToken) return false;
+            if (t.disposition !== targetToken.disposition) return false;
             if (isIgnoredForGangUp(t)) return false;
             return withinRange(targetToken, t, meleeRange);
         });
@@ -628,14 +621,11 @@ export function calculateGangUp(attackerToken, targetToken) {
 }
 
 function withinRange(origin, target, range, epsilon = Number.EPSILON) {
-    origin = origin instanceof TokenDocument ? origin.object : origin;
-    target = target instanceof TokenDocument ? target.object : target;
-    if (Math.abs(origin.document.elevation - target.document.elevation) >= 1) {
+    if (Math.abs(origin.elevation - target.elevation) >= 1) {
         return false;
     }
-    const grid_unit = canvas.grid.distance;
     let distance = measureDistance(origin, target);
-    distance /= grid_unit;
+    distance /= canvas.grid.distance;
     return distance <= (range + epsilon);
 }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -180,8 +180,8 @@ export function getTargetedToken(originActors) {
  * Gets the first selected token
  */
 export function getSelectedToken(originActors) {
-    const originActorIds = new Set(originActors.map(a => a.id));
-    return canvas.tokens.controlled.find((t) => !originActorIds.has(t.actor.id));
+    const originActorIds = new Set(originActors?.map(a => a.id) ?? []);
+    return canvas.tokens.controlled.find((t) => t.actor && !originActorIds.has(t.actor.id));
 }
 
 /**

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -172,17 +172,16 @@ export async function simple_form(title, fields, callback) {
 /**
  * Gets the first targeted token
  */
-export function get_targeted_token() {
-    /**
-     * Sets the difficulty as the parry value of the targeted
-     * or selected token
-     */
-    const targets = game.user.targets;
-    let objective;
-    if (targets.size) {
-        objective = Array.from(targets)[0];
-    }
-    return objective;
+export function getTargetedToken(originActors) {
+    return game.user.targets.first() ?? getSelectedToken(originActors);
+}
+
+/**
+ * Gets the first selected token
+ */
+export function getSelectedToken(originActors) {
+    const originActorIds = new Set(originActors.map(a => a.id));
+    return canvas.tokens.controlled.find((t) => !originActorIds.has(t.actor.id));
 }
 
 /**
@@ -217,24 +216,24 @@ export function addEventListenerAll(
 }
 
 function measurePath(waypoints) {
-    const use_grid_calc = SettingsUtils.getWorldSetting(WORLD_SETTING_KEYS.rangeCalcGrid);
+    const useGridCalc = SettingsUtils.getWorldSetting(WORLD_SETTING_KEYS.rangeCalcGrid);
     const path = canvas.grid.measurePath(waypoints);
-    return use_grid_calc ? path.distance : path.euclidean;
+    return useGridCalc ? path.distance : path.euclidean;
 }
 
-function getTokenGridSpaces(token) {
+function getTokenGridSpaces(tokenDoc) {
     const gridSpaces = [];
     if (canvas.grid.isGridless) {
         //If we have a gridless grid, divide our token into 1" sections based on the grid size
         //We'll use those as our occupied "spaces" even though there are none
-        const halfGrid = canvas.grid.size;
+        const halfGrid = canvas.grid.size / 2;
         const start = {
-            x: token.bounds.left + halfGrid,
-            y: token.bounds.top + halfGrid,
+            x: tokenDoc.x + halfGrid,
+            y: tokenDoc.y + halfGrid,
         };
         const dimensions = {
-            width: Math.max(1, Math.round(token.document.width)),
-            height: Math.max(1, Math.round(token.document.height)),
+            width: Math.max(1, Math.round(tokenDoc.width)),
+            height: Math.max(1, Math.round(tokenDoc.height)),
         };
 
         for (let i = 0; i < dimensions.width; ++i) {
@@ -247,7 +246,7 @@ function getTokenGridSpaces(token) {
             }
         }
     } else {
-        for (const space of token.document.getOccupiedGridSpaceOffsets()) {
+        for (const space of tokenDoc.getOccupiedGridSpaceOffsets()) {
             gridSpaces.push({ coords: canvas.grid.getCenterPoint(space) });
         }
     }
@@ -255,6 +254,8 @@ function getTokenGridSpaces(token) {
 }
 
 export function measureDistance(tokenA, tokenB) {
+    tokenA = Utils.toTokenDoc(tokenA);
+    tokenB = Utils.toTokenDoc(tokenB);
     if (!tokenA || !tokenB) {
         ui.notifications.error("measureDistance requires two tokens");
         return 0;
@@ -288,7 +289,7 @@ export function measureDistance(tokenA, tokenB) {
         }
     }
 
-    let measured_distance = measurePath([
+    let measuredDistance = measurePath([
         closestPair.a.coords,
         closestPair.b.coords,
     ]);
@@ -304,11 +305,11 @@ export function measureDistance(tokenA, tokenB) {
             };
 
             const distanceToEdge = (tokenA.scene.grid.distance / 2) / Math.max(Math.abs(dir.x), Math.abs(dir.y));
-            measured_distance -= (distanceToEdge * 2); //Times 2 because we're offsetting the distance for both tokens
+            measuredDistance -= (distanceToEdge * 2); //Times 2 because we're offsetting the distance for both tokens
         }
     }
 
-    return measured_distance;
+    return measuredDistance;
 }
 
 export class Utils {
@@ -634,6 +635,24 @@ export class Utils {
         }
 
         return false;
+    }
+
+    static toTokenDoc(entity) {
+        if (entity instanceof TokenDocument) { return entity; }
+        if (entity instanceof foundry.canvas.placeables.Token) { return entity.document; }
+        return null;
+    }
+
+    static toToken(entity) {
+        if (entity instanceof foundry.canvas.placeables.Token) { return entity; }
+        if (entity instanceof TokenDocument) { return entity.object; }
+        return null;
+    }
+
+    static toActor(entity) {
+        if (entity instanceof Actor) { return entity; }
+        if (entity instanceof TokenDocument || entity instanceof foundry.canvas.placeables.Token) { return entity.actor; }
+        return null;
     }
 }
 


### PR DESCRIPTION
- Reworked several functions to only use TokenDocuments
- Added helper functions for converting to Token, TokenDoc, and Actor
- Fixed a slight inaccuracy with gridless distance
- A bunch of renaming and cleanup

## Summary by Sourcery

Refactor token and actor handling across cards and utilities to rely on TokenDocuments and shared helpers, while improving distance/target calculations and updating related APIs.

New Features:
- Introduce utility helpers to convert between generic entities, tokens, token documents, and actors.
- Add new getTargetedToken and getSelectedToken helpers to centralize selection/target resolution.
- Expose a new game.brsw.createAttributeCard API while keeping the old create_atribute_card as a deprecated wrapper.

Bug Fixes:
- Correct distance measurement and gridless range handling for token-based calculations.
- Fix gang-up and range calculations to consistently use token disposition/elevation and token documents.

Enhancements:
- Unify roll option and TN calculation flows to reuse shared helpers for target and distance logic.
- Rename and modernize various functions (e.g., calculateDistance, getNewRollOptions, getTraitRollDifficulty) for consistency and clarity.
- Simplify resist and macro execution flows to use the new helpers and card creation APIs.

Documentation:
- Update documentation examples to reference the new createAttributeCard API instead of the deprecated create_attribute_card.