### PR TITLE
Deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -317,7 +317,7 @@
 * Actions: Added skill_linked_attribute selector (Dan Brown)
 * Bugfix: Better support for cases where there are no tokens in a scene. (Dan Brown)
 * Translations: Update Spanish translations. (Weblate team)
-* API: Expose create_damage_card for API usage (Dan Brown)
+* API: Expose createDamageCard for API usage (Dan Brown)
 * Bugfix: Toggle off dead when undoing damage (Dan Brown)
 * Bugfix: Fixed bug in dmgMod actions (Dan Brown)
 * V13 compatibility: Avoid showing the system default roll when clicking on same places.
@@ -1155,7 +1155,7 @@ NOTE: NO NEW FEATURES, JUST COMPATIBILITY WITH SWADE 3.2
 * Global actions: Added a selector for major hindrances
 * Bug: SKills in global actions were case-sensitive
 * Cards: Drag and drop now rolls damage when default action is "show card, roll trait and roll damage"
-* Macro support: Macros now pass html to roll_item, that means than token action HUD should now support default checked on global actions
+* Macro support: Macros now pass html to rollItem, that means than token action HUD should now support default checked on global actions
 * Bug: Added an await to avoid a race condition that could make damage rolls not happen at times.
 
 ## Version 2.58 aka More bugs, can I blame v9?

--- a/docs/Global-Actions.md
+++ b/docs/Global-Actions.md
@@ -164,7 +164,7 @@ The following variables are included in the scope when running a macro via `runS
 
 ## API
 
-You can define global actions within a module. To add actions, listen to the hook `brswReady` and call `game.brsw.add_actions`. If the id of an action matches one of the default actions in BR2, your action will replace it. See the example below.
+You can define global actions within a module. To add actions, listen to the hook `brswReady` and call `game.brsw.addActions`. If the id of an action matches one of the default actions in BR2, your action will replace it. See the example below.
 
 
 ```js
@@ -208,7 +208,7 @@ Hooks.once('brswReady', () => {
         }
     ];
 
-    game.brsw.add_actions(CUSTOM_BRSW_GLOBAL_ACTIONS);
+    game.brsw.addActions(CUSTOM_BRSW_GLOBAL_ACTIONS);
 })
 ```
 
@@ -217,7 +217,7 @@ user wants to use their own global actions.
 
 ```js
 if (game.settings.get("yourModuleID", "TurnOnOrOffMyModuleGlobalActions")) {
-    game.brsw.add_actions(CUSTOM_BRSW_GLOBAL_ACTIONS);
+    game.brsw.addActions(CUSTOM_BRSW_GLOBAL_ACTIONS);
 }
 ```
 

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -25,7 +25,7 @@ The following information assumes a passing knowledge of both javascript and Fou
 The module exposes an API in game.brsw.
 
 ```js
-game.brsw.add_actions(actions)
+game.brsw.addActions(actions)
 /**
  * Adds an array of actions to the available ones. The array should be in the same format as builtin-actions.js.
  * The array is cleared when reloading and should be set again
@@ -101,7 +101,7 @@ game.brsw.GLOBAL_ACTIONS
 ```
 
 ```js
-game.brsw.get_roll_options(old_options)
+game.brsw.getRollOptions(old_options)
 /**
  * Gets the roll options from the card html. Don't use, it is here just
  * for compatibility (to keep old macros from breaking). Use the brCommondCard

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -112,7 +112,7 @@ game.brsw.getRollOptions(old_options)
 ```
 
 ```js
-game.brsw.create_incapacitation_card(token_id)
+game.brsw.createIncapacitationCard(token_id)
 /**
  * Shows an incapacitation card an
  * @param {string} token_id As it comes from damage its target is always a token

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -47,7 +47,7 @@ game.brsw.createAttributeCard()
 ```
 
 ```js
-game.brsw.create_attribute_card_from_id(token_id, actor_id, name)
+game.brsw.createAttributeCardFromId(token_id, actor_id, name)
 /**
  * Creates an attribute card from a token or actor id
  *
@@ -61,7 +61,7 @@ game.brsw.create_attribute_card_from_id(token_id, actor_id, name)
  ```
 
 ```js
-game.brsw.roll_attribute(brCard, expend_bennie)
+game.brsw.rollAttribute(brCard, expend_bennie)
 /**
  * Roll an attribute showing from an existing card
  *

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -159,7 +159,7 @@ game.brsw.roll_item(brCard, html, expend_bennie, roll_damage)
  ```
 
 ```js
-game.brsw.create_skill_card(origin, skillId)
+game.brsw.createSkillCard(origin, skillId)
 /**
  * Creates a chat card for a skill
  *
@@ -170,7 +170,7 @@ game.brsw.create_skill_card(origin, skillId)
  ```
 
 ```js
-game.brsw.create_skill_card_from_id(token_id, actor_id, skillId)
+game.brsw.createSkillCardFromId(token_id, actor_id, skillId)
 /**
  * Creates a skill card from a token or actor id, mainly for use in macros
  *
@@ -184,7 +184,7 @@ game.brsw.create_skill_card_from_id(token_id, actor_id, skillId)
  ```
 
 ```js
- game.brsw.roll_skill(brCard, expend_bennie)
+ game.brsw.rollSkill(brCard, expend_bennie)
  /**
  * Roll an existing skill card
  *

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -79,9 +79,9 @@ game.brsw.dialog
 ```
 
 ```js
-game.brsw.get_action_from_click(event)
+game.brsw.getActionFromClick(event)
 /**
-/* Given a js event it checks the setting for the kind of action that shoul be done
+/* Given a js event it checks the setting for the kind of action that should be done
 /* i.e. show the card, show and roll, do a system roll, etc..
 */
 ```

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -114,7 +114,7 @@ game.brsw.getRollOptions(old_options)
 ```js
 game.brsw.createIncapacitationCard(token_id)
 /**
- * Shows an incapacitation card an
+ * Shows an incapacitation card
  * @param {string} token_id As it comes from damage its target is always a token
  */
 ```

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -104,7 +104,7 @@ game.brsw.GLOBAL_ACTIONS
 game.brsw.getRollOptions(old_options)
 /**
  * Gets the roll options from the card html. Don't use, it is here just
- * for compatibility (to keep old macros from breaking). Use the brCommondCard
+ * for compatibility (to keep old macros from breaking). Use the brCommonCard
  * class, as it is much more powerful and clean.
  *
  * @param old_options - Options used as default

--- a/docs/More-Functionalities.md
+++ b/docs/More-Functionalities.md
@@ -120,7 +120,7 @@ game.brsw.create_incapacitation_card(token_id)
 ```
 
 ```js
-game.brsw.create_item_card(origin, item_id)
+game.brsw.createItemCard(origin, item_id)
 /**
  * Creates a chat card for an item
  *
@@ -131,7 +131,7 @@ game.brsw.create_item_card(origin, item_id)
 ```
 
 ```js
-game.brsw.create_item_card_from_id(token_id, actor_id, itemid)
+game.brsw.createItemCardFromId(token_id, actor_id, itemid)
 /**
  * Creates an item card from a token or actor id, mainly for use in macros
  *
@@ -145,7 +145,7 @@ game.brsw.create_item_card_from_id(token_id, actor_id, itemid)
 ```
 
 ```js
-game.brsw.roll_item(brCard, html, expend_bennie, roll_damage)
+game.brsw.rollItem(brCard, html, expend_bennie, roll_damage)
 /**
  * Roll and existing item card
  *

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -62,7 +62,7 @@ export class BrCommonCard {
             const data = this.message.getFlag("betterrolls-swade2", "br_data");
             if (data) {
                 this.load(data);
-                // TODO: Check if activate_common_listeners can be made a method of this class and simplified.
+                // TODO: Check if activateCommonListeners can be made a method of this class and simplified.
             }
         } else {
             this.id = broofa();

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -198,8 +198,6 @@ export class BrCommonCard {
         if (this.token_id) {
             const { token } = this;
             if (token) {
-                // Token can be undefined even with and id the scene is note
-                // ready or the token has been removed.
                 return token.actor;
             }
         }
@@ -238,7 +236,7 @@ export class BrCommonCard {
     }
 
     get item() {
-        let item = this.actor.items.find((item) => item.id === this.item_id);
+        let item = this.actor?.items.find((item) => item.id === this.item_id);
         if (!item) {
             item = fromUuidSync(this.item_id);
         }

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -6,7 +6,7 @@ import { BRSW2_CONST } from "./brsw2-const.js";
 import {
   create_common_card,
   getActionFromClick,
-  get_actor_from_ids,
+  getActorFromIds,
   process_common_actions,
   roll_trait,
   spend_bennie,
@@ -64,7 +64,7 @@ function createAttributeCardFromId(
   name,
   { actions_stored = {} } = {},
 ) {
-  const actor = get_actor_from_ids(token_id, actor_id);
+  const actor = getActorFromIds(token_id, actor_id);
   return createAttributeCard(actor, name, {
     actions_stored: actions_stored,
   });

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -73,7 +73,7 @@ function createAttributeCardFromId(
 /**
  * Hooks the public functions to a global object
  */
-export function attribute_card_hooks() {
+export function exposeAttributeAPI() {
   Utils.exposeAPI("createAttributeCard", createAttributeCard, "create_atribute_card");
   Utils.exposeAPI("createAttributeCardFromId", createAttributeCardFromId, "create_attribute_card_from_id");
   Utils.exposeAPI("rollAttribute", rollAttribute, "roll_attribute");

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -120,7 +120,7 @@ export function activate_attribute_listeners(app, html) {
  * @param {BrCommonCard} card Message date
  * @param html Html produced
  */
-export function activate_attribute_card_listeners(card, html) {
+export function activateAttributeCardListeners(card, html) {
   const roll_buttons = html.querySelectorAll(".brsw-roll-button");
   for (const roll_button of roll_buttons) {
     roll_button.addEventListener("click", async (ev) => {

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -58,7 +58,7 @@ async function createAttributeCard(origin, name, { actions_stored = {} } = {},) 
  *   and a boolean meaning if they need to set on or off
  * @return {Promise} a promise for the ChatMessage object
  */
-function create_attribute_card_from_id(
+function createAttributeCardFromId(
   token_id,
   actor_id,
   name,
@@ -74,16 +74,9 @@ function create_attribute_card_from_id(
  * Hooks the public functions to a global object
  */
 export function attribute_card_hooks() {
-  game.brsw.create_atribute_card = (...args) => {
-    foundry.utils.logCompatibilityWarning(
-      "game.brsw.create_atribute_card is deprecated. Use game.brsw.createAttributeCard instead.",
-      { since: "5.19.0" }
-    );
-    return createAttributeCard(...args);
-  };
-  game.brsw.createAttributeCard = createAttributeCard;
-  game.brsw.create_attribute_card_from_id = create_attribute_card_from_id;
-  game.brsw.roll_attribute = roll_attribute;
+  Utils.exposeAPI("createAttributeCard", createAttributeCard, "create_atribute_card");
+  Utils.exposeAPI("createAttributeCardFromId", createAttributeCardFromId, "create_attribute_card_from_id");
+  Utils.exposeAPI("rollAttribute", rollAttribute, "roll_attribute");
 }
 
 /**
@@ -106,7 +99,7 @@ async function attribute_click_listener(ev, target) {
   if (action.includes("dialog")) {
     game.brsw.dialog.show_card(brCard);
   } else if (action.includes("trait")) {
-    await roll_attribute(brCard, false);
+    await rollAttribute(brCard, false);
   }
 }
 
@@ -132,7 +125,7 @@ export function activate_attribute_card_listeners(card, html) {
   for (const roll_button of roll_buttons) {
     roll_button.addEventListener("click", async (ev) => {
       ev.stopPropagation();
-      await roll_attribute(
+      await rollAttribute(
         card,
         ev.currentTarget.classList.contains("roll-bennie-button"),
       );
@@ -146,7 +139,7 @@ export function activate_attribute_card_listeners(card, html) {
  * @param {BrCommonCard} brCard The card being rolled
  * @param {boolean} expend_bennie True if we want to spend a bennie
  */
-export async function roll_attribute(brCard, expend_bennie) {
+export async function rollAttribute(brCard, expend_bennie) {
   const extra_data = { modifiers: [] };
   const macros = [];
   for (const action of brCard.getSelectedActions()) {

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -30,7 +30,7 @@ import {
 import {
     activate_item_card_listeners,
     activate_item_listeners,
-    expose_item_functions,
+    exposeItemCardAPI,
 } from "./item_card.js";
 import { activate_remove_status_card_listeners } from "./remove_status_cards.js";
 import { migrateOptionalRules, registerDSNSettings, registerSettings, updateCachedUserSettings, updateCachedWorldSettings } from "./settings.js";
@@ -68,7 +68,7 @@ Hooks.on(`ready`, async () => {
     // Create a base object to hook functions
     exposeAttributeAPI();
     exposeSkillCardAPI();
-    expose_item_functions();
+    exposeItemCardAPI();
     expose_global_actions_functions();
     expose_card_class();
     incapacitation_card_hooks();
@@ -266,7 +266,7 @@ function create_macro_command(data, actor_id, token_id) {
                 message = await game.brsw.createSkillCardFromId('${token_id}', '${actor_id}', '${data._id
         }');
             } else {
-                message = await game.brsw.create_item_card_from_id('${token_id}', '${actor_id}', '${data._id
+                message = await game.brsw.createItemCardFromId('${token_id}', '${actor_id}', '${data._id
         }');
             }
             if (event) {
@@ -274,7 +274,7 @@ function create_macro_command(data, actor_id, token_id) {
                     if (${data.type === "skill"}) {
                         game.brsw.rollSkill(message, $(message.content), false)
                     } else {
-                        game.brsw.roll_item(message, $(message.content), false, behaviour.includes('damage'))
+                        game.brsw.rollItem(message, $(message.content), false, behaviour.includes('damage'))
                     }
                 }
             }

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -290,7 +290,7 @@ function create_attribute_macro(data) {
       origin = await fromUuid("${data.uuid}");
       const brCard = await game.brsw.createAttributeCard(origin, "${data.attribute}");
       if (behaviour.includes('trait')) {
-        game.brsw.roll_attribute(brCard, false);
+        game.brsw.rollAttribute(brCard, false);
       }
     }
   `;

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -3,39 +3,39 @@
     Macro, CONFIG, foundry, Item, ModuleManagement, $ */
 import { BrCommonCard } from "./BrCommonCard.js";
 import {
-    activate_attribute_card_listeners,
+    activateAttributeCardListeners,
     activate_attribute_listeners,
     exposeAttributeAPI,
 } from "./attribute_card.js";
 import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
-import { setup_dialog } from "./card-dialog.js";
+import { setupDialog } from "./card-dialog.js";
 import {
-    activate_common_listeners,
+    activateCommonListeners,
     exposeCardClass,
     getActionFromClick,
 } from "./cards_common.js";
 import { create_unshaken_wrapper, create_unstun_wrapper } from "./combat.js";
-import { activate_damage_card_listeners } from "./damage_card.js";
+import { activateDamageCardListeners } from "./damage_card.js";
 import {
     exposeGlobalActionsAPI,
     registerActions,
     registerGMActionsSettings
 } from "./global_actions.js";
-import { setup_chat_button } from "./gm_actions.js";
+import { setupChatButton } from "./gm_actions.js";
 import {
-    activate_incapacitation_card_listeners,
+    activateIncapacitationCardListeners,
     exposeIncapacitationCardAPI,
 } from "./incapacitation_card.js";
 import {
-    activate_item_card_listeners,
+    activateItemCardListeners,
     activate_item_listeners,
     exposeItemCardAPI,
 } from "./item_card.js";
-import { activate_remove_status_card_listeners } from "./remove_status_cards.js";
+import { activateRemoveStatusCardListeners } from "./remove_status_cards.js";
 import { migrateOptionalRules, registerDSNSettings, registerSettings, updateCachedUserSettings, updateCachedWorldSettings } from "./settings.js";
 import {
-    activate_skill_card_listeners,
+    activateSkillCardListeners,
     activate_skill_listeners,
     exposeSkillCardAPI,
 } from "./skill_card.js";
@@ -72,7 +72,7 @@ Hooks.on(`ready`, async () => {
     exposeGlobalActionsAPI();
     exposeCardClass();
     exposeIncapacitationCardAPI();
-    setup_chat_button();
+    setupChatButton();
     await cacheSkillData();
 
     // Load partials.
@@ -98,8 +98,8 @@ Hooks.on(`ready`, async () => {
         game.swade.effectCallbacks.set("stunned", create_unstun_wrapper);
     }
 
-    compatibility_warnings();
-    setup_dialog();
+    compatibilityWarnings();
+    setupDialog();
 
     // Remove the first hook from the hotbarDrop, hoping it is the system's
     const system_event = Hooks.events.hotbarDrop.find(
@@ -120,22 +120,22 @@ Hooks.on(`ready`, async () => {
 // Hooks on render
 
 function activateCardListeners(brCard, html, message) {
-    activate_common_listeners(brCard, html);
+    activateCommonListeners(brCard, html);
     if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD) {
-        activate_attribute_card_listeners(brCard, html);
+        activateAttributeCardListeners(brCard, html);
     } else if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD) {
-        activate_skill_card_listeners(brCard, html);
+        activateSkillCardListeners(brCard, html);
     } else if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD) {
-        activate_item_card_listeners(brCard, html);
+        activateItemCardListeners(brCard, html);
     } else if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_DMG_CARD) {
-        activate_damage_card_listeners(message, html);
+        activateDamageCardListeners(message, html);
     } else if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_INC_CARD) {
-        activate_incapacitation_card_listeners(message, html);
+        activateIncapacitationCardListeners(message, html);
     } else if (
         brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_UNSHAKE_CARD ||
         brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_UNSTUN_CARD
     ) {
-        activate_remove_status_card_listeners(brCard, html, brCard.type);
+        activateRemoveStatusCardListeners(brCard, html, brCard.type);
     }
 }
 
@@ -364,7 +364,7 @@ Hooks.once("diceSoNiceReady", () => {
 });
 
 //Compatibility warnings:
-function compatibility_warnings() {
+function compatibilityWarnings() {
     if (game.modules.get("swade-tools")?.active) {
         new foundry.applications.api.DialogV2({
             window: { title: "BRSW.CompatibilityHeadline" },

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -18,7 +18,7 @@ import {
 import { create_unshaken_wrapper, create_unstun_wrapper } from "./combat.js";
 import { activate_damage_card_listeners } from "./damage_card.js";
 import {
-    expose_global_actions_functions,
+    exposeGlobalActionsAPI,
     registerActions,
     register_gm_actions_settings
 } from "./global_actions.js";
@@ -69,7 +69,7 @@ Hooks.on(`ready`, async () => {
     exposeAttributeAPI();
     exposeSkillCardAPI();
     exposeItemCardAPI();
-    expose_global_actions_functions();
+    exposeGlobalActionsAPI();
     expose_card_class();
     incapacitation_card_hooks();
     setup_chat_button();

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -12,7 +12,7 @@ import { BRSW2_CONST } from "./brsw2-const.js";
 import { setup_dialog } from "./card-dialog.js";
 import {
     activate_common_listeners,
-    expose_card_class,
+    exposeCardClass,
     getActionFromClick,
 } from "./cards_common.js";
 import { create_unshaken_wrapper, create_unstun_wrapper } from "./combat.js";
@@ -20,7 +20,7 @@ import { activate_damage_card_listeners } from "./damage_card.js";
 import {
     exposeGlobalActionsAPI,
     registerActions,
-    register_gm_actions_settings
+    registerGMActionsSettings
 } from "./global_actions.js";
 import { setup_chat_button } from "./gm_actions.js";
 import {
@@ -39,7 +39,7 @@ import {
     activate_skill_listeners,
     exposeSkillCardAPI,
 } from "./skill_card.js";
-import { SettingsUtils, TelemetryUtils, cacheSkillData, measureDistance } from "./utils.js";
+import { SettingsUtils, TelemetryUtils, Utils, cacheSkillData, measureDistance } from "./utils.js";
 import { activate_vehicle_listeners } from "./vehicle_card.js";
 
 // Init Hook
@@ -47,13 +47,13 @@ Hooks.on(`init`, () => {
     game.brsw = {};
     game.brsw.CONST = BRSW2_CONST;
     game.brsw.cascade_count = 0;
-    game.brsw.get_action_from_click = getActionFromClick;
-    game.brsw.measureDistance = measureDistance;
+    Utils.exposeAPI("getActionFromClick", getActionFromClick, "get_action_from_click");
+    Utils.exposeAPI("measureDistance", measureDistance);
 
     registerSettings();
 
     registerActions();
-    register_gm_actions_settings();
+    registerGMActionsSettings();
 });
 
 // Base Hook
@@ -70,7 +70,7 @@ Hooks.on(`ready`, async () => {
     exposeSkillCardAPI();
     exposeItemCardAPI();
     exposeGlobalActionsAPI();
-    expose_card_class();
+    exposeCardClass();
     exposeIncapacitationCardAPI();
     setup_chat_button();
     await cacheSkillData();
@@ -256,7 +256,7 @@ Hooks.on("dropCanvasData", (canvas, item) => {
 function create_macro_command(data, actor_id, token_id) {
     const bt = "`";
     return `
-            let behaviour = game.brsw.get_action_from_click(event);
+            let behaviour = game.brsw.getActionFromClick(event);
             if (behaviour === 'system') {
                 game.swade.rollItemMacro(${bt}${data.name}${bt});
                 return;
@@ -283,7 +283,7 @@ function create_macro_command(data, actor_id, token_id) {
 
 function create_attribute_macro(data) {
     return `
-    let behaviour = game.brsw.get_action_from_click(event);
+    let behaviour = game.brsw.getActionFromClick(event);
     if (behaviour === 'system') {
       game.swade.rollItemMacro("${data.attribute}");
     } else {

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -37,7 +37,7 @@ import { migrateOptionalRules, registerDSNSettings, registerSettings, updateCach
 import {
     activate_skill_card_listeners,
     activate_skill_listeners,
-    skill_card_hooks,
+    exposeSkillCardAPI,
 } from "./skill_card.js";
 import { SettingsUtils, TelemetryUtils, cacheSkillData, measureDistance } from "./utils.js";
 import { activate_vehicle_listeners } from "./vehicle_card.js";
@@ -67,7 +67,7 @@ Hooks.on(`ready`, async () => {
 
     // Create a base object to hook functions
     exposeAttributeAPI();
-    skill_card_hooks();
+    exposeSkillCardAPI();
     expose_item_functions();
     expose_global_actions_functions();
     expose_card_class();
@@ -263,7 +263,7 @@ function create_macro_command(data, actor_id, token_id) {
             }
             let message;
             if (${data.type === "skill"}) {
-                message = await game.brsw.create_skill_card_from_id('${token_id}', '${actor_id}', '${data._id
+                message = await game.brsw.createSkillCardFromId('${token_id}', '${actor_id}', '${data._id
         }');
             } else {
                 message = await game.brsw.create_item_card_from_id('${token_id}', '${actor_id}', '${data._id
@@ -272,7 +272,7 @@ function create_macro_command(data, actor_id, token_id) {
             if (event) {
                 if (behaviour.includes('trait')) {
                     if (${data.type === "skill"}) {
-                        game.brsw.roll_skill(message, $(message.content), false)
+                        game.brsw.rollSkill(message, $(message.content), false)
                     } else {
                         game.brsw.roll_item(message, $(message.content), false, behaviour.includes('damage'))
                     }

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -25,7 +25,7 @@ import {
 import { setup_chat_button } from "./gm_actions.js";
 import {
     activate_incapacitation_card_listeners,
-    incapacitation_card_hooks,
+    exposeIncapacitationCardAPI,
 } from "./incapacitation_card.js";
 import {
     activate_item_card_listeners,
@@ -71,7 +71,7 @@ Hooks.on(`ready`, async () => {
     exposeItemCardAPI();
     exposeGlobalActionsAPI();
     expose_card_class();
-    incapacitation_card_hooks();
+    exposeIncapacitationCardAPI();
     setup_chat_button();
     await cacheSkillData();
 

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -5,7 +5,7 @@ import { BrCommonCard } from "./BrCommonCard.js";
 import {
     activate_attribute_card_listeners,
     activate_attribute_listeners,
-    attribute_card_hooks,
+    exposeAttributeAPI,
 } from "./attribute_card.js";
 import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
@@ -66,7 +66,7 @@ Hooks.on(`ready`, async () => {
     updateCachedUserSettings();
 
     // Create a base object to hook functions
-    attribute_card_hooks();
+    exposeAttributeAPI();
     skill_card_hooks();
     expose_item_functions();
     expose_global_actions_functions();

--- a/scripts/card-dialog.js
+++ b/scripts/card-dialog.js
@@ -1,7 +1,7 @@
 // A dialog to manage br cards
 /* global game, console, renderTemplate */
 
-export function setup_dialog() {
+export function setupDialog() {
   const dialog_element = document.createElement("dialog");
   dialog_element.setAttribute("id", "br-card-dialog");
   dialog_element.classList.add("twbr:bg-gray-700");

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -480,7 +480,7 @@ export function getActionFromClick(event) {
  *
  * @param old_options - Options used as default
  */
-export function get_roll_options(old_options, brCard) {
+export function getRollOptions(old_options, brCard) {
     const modifiers = old_options?.additionalMods || [];
     const dmg_modifiers = old_options?.dmgMods || [];
     const tn = old_options?.tn || 4;
@@ -741,7 +741,7 @@ async function getNewRollOptions(
         extraOptions.rof = extraData.rof;
     }
 
-    const options = get_roll_options(extraOptions, brCard);
+    const options = getRollOptions(extraOptions, brCard);
     rollOptions.rof = options.rof || 1;
 
     // Trait modifier

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -9,7 +9,7 @@ import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { WORLD_SETTING_KEYS } from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 import {
-    roll_item,
+    rollItem,
     runMacros,
     spendPP,
 } from "./item_card.js";
@@ -381,9 +381,9 @@ function create_macro_command_from_card(brCard) {
     let roll_function = "";
     let id = "";
     if (brCard.item_id) {
-        card_function_name = "create_item_card_from_id";
+        card_function_name = "createItemCardFromId";
         roll_function =
-            "game.brsw.roll_item(message, $(message.content), false, behaviour.includes('damage'));";
+            "game.brsw.rollItem(message, $(message.content), false, behaviour.includes('damage'));";
         id = brCard.item_id;
     } else if (brCard.skill) {
         card_function_name = "createSkillCardFromId";
@@ -1239,7 +1239,7 @@ async function duplicate_message(message, event) {
             await rollSkill(brCard, false);
         } else if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD) {
             const roll_damage = action.includes("damage");
-            await roll_item(brCard, $(brCard.message.content), false, roll_damage);
+            await rollItem(brCard, $(brCard.message.content), false, roll_damage);
         }
     }
     return new_message;

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -23,7 +23,7 @@ import { TraitRoll } from "./rolls.js";
 import {
     calculateDistance,
     getTNFromToken,
-    roll_skill,
+    rollSkill,
 } from "./skill_card.js";
 import {
     SettingsUtils,
@@ -132,7 +132,7 @@ export async function spend_bennie(actor) {
  * @param token_id
  * @param actor_id
  */
-export function get_actor_from_ids(token_id, actor_id) {
+export function getActorFromIds(token_id, actor_id) {
     if (canvas.tokens) {
         let token;
         if (token_id) {
@@ -386,8 +386,8 @@ function create_macro_command_from_card(brCard) {
             "game.brsw.roll_item(message, $(message.content), false, behaviour.includes('damage'));";
         id = brCard.item_id;
     } else if (brCard.skill) {
-        card_function_name = "create_skill_card_from_id";
-        roll_function = "game.brsw.roll_skill(message, $(message.content), false);";
+        card_function_name = "createSkillCardFromId";
+        roll_function = "game.brsw.rollSkill(message, $(message.content), false);";
         id = brCard.trait.id;
     } else if (brCard.attribute) {
         card_function_name = "createAttributeCardFromId";
@@ -1236,7 +1236,7 @@ async function duplicate_message(message, event) {
         if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD) {
             await rollAttribute(brCard, false);
         } else if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD) {
-            await roll_skill(brCard, false);
+            await rollSkill(brCard, false);
         } else if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD) {
             const roll_damage = action.includes("damage");
             await roll_item(brCard, $(brCard.message.content), false, roll_damage);

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -4,7 +4,7 @@
 // noinspection JSUnusedAssignment
 
 import { BrCommonCard } from "./BrCommonCard.js";
-import { roll_attribute } from "./attribute_card.js";
+import { rollAttribute } from "./attribute_card.js";
 import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { WORLD_SETTING_KEYS } from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
@@ -390,9 +390,9 @@ function create_macro_command_from_card(brCard) {
         roll_function = "game.brsw.roll_skill(message, $(message.content), false);";
         id = brCard.trait.id;
     } else if (brCard.attribute) {
-        card_function_name = "create_attribute_card_from_id";
+        card_function_name = "createAttributeCardFromId";
         roll_function =
-            "game.brsw.roll_attribute(message, $(message.content), false);";
+            "game.brsw.rollAttribute(message, $(message.content), false);";
         id = brCard.trait.name;
     }
     return `
@@ -1234,7 +1234,7 @@ async function duplicate_message(message, event) {
         const brCard = new BrCommonCard(message);
         const card_type = brCard.type;
         if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD) {
-            await roll_attribute(brCard, false);
+            await rollAttribute(brCard, false);
         } else if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD) {
             await roll_skill(brCard, false);
         } else if (card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD) {

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -54,7 +54,7 @@ export function BRWSRoll() {
  * Makes the BrCommonCard class accessible
  *
  */
-export function expose_card_class() {
+export function exposeCardClass() {
     game.brsw.BrCommonCard = BrCommonCard;
 }
 
@@ -396,7 +396,7 @@ function create_macro_command_from_card(brCard) {
         id = brCard.trait.name;
     }
     return `
-  let behaviour = game.brsw.get_action_from_click(event);
+  let behaviour = game.brsw.getActionFromClick(event);
   if (behaviour === 'system') {
     game.swade.rollItemMacro(\`${brCard.render_data.header.title}\`);
     return;

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -214,7 +214,7 @@ function toggle_mods_popup(element, brCard) {
  * @param {BrCommonCard} brCard
  * @param {HTMLElement} html - html of the card
  */
-export function activate_common_listeners(brCard, html) {
+export function activateCommonListeners(brCard, html) {
     // The message will be rendered at creation and each time a flag is added
     // Actor will be undefined if this is called before flags are set
     if (brCard.actor) {

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -21,7 +21,7 @@ import { Utils, addEventListenerAll } from "./utils.js";
  * @param {string} damage_text
  * @param {string} heavyDamage
  */
-export async function create_damage_card(
+export async function createDamageCard(
     token_id,
     damage,
     damage_text,

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -215,7 +215,7 @@ async function undo_damage(message) {
  * @param message Message date
  * @param html Html produced
  */
-export function activate_damage_card_listeners(message, html) {
+export function activateDamageCardListeners(message, html) {
     const brCard = new BrCommonCard(message);
     html.querySelector(".brsw-undo-damage")?.addEventListener("click", async () => {
         await undo_damage(message);

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -9,8 +9,8 @@ import {
     spend_bennie,
 } from "./cards_common.js";
 import {
-    create_incapacitation_card,
-    create_injury_card,
+    createIncapacitationCard,
+    createInjuryCard,
 } from "./incapacitation_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
 
@@ -235,7 +235,7 @@ export function activate_damage_card_listeners(message, html) {
     html.querySelector(".brsw-show-incapacitation")?.addEventListener("click", () => {
         // noinspection JSIgnoredPromiseFromCall
         brCard.closePopout(); //We assume we're done with the card at this point so close any popouts
-        create_incapacitation_card(brCard.token_id);
+        createIncapacitationCard(brCard.token_id);
     });
     html.querySelector(".brsw-mark-defeated")?.addEventListener("click", async () => {
         await brCard.actor.toggleStatusEffect("incapacitated", { active: false });
@@ -244,7 +244,7 @@ export function activate_damage_card_listeners(message, html) {
     });
     html.querySelector(".brsw-injury-button")?.addEventListener("click", () => {
         // noinspection JSIgnoredPromiseFromCall
-        create_injury_card(brCard.token_id, "gritty");
+        createInjuryCard(brCard.token_id, "gritty");
     });
 }
 

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -507,7 +507,7 @@ function get_gm_actions() {
     return gm_actions;
 }
 
-export function register_gm_actions_settings() {
+export function registerGMActionsSettings() {
     SettingsUtils.registerSetting("gm_actions", {
         name: "GM Actions",
         default: get_gm_actions(),

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -4,7 +4,7 @@
 
 import { SYSTEM_GLOBAL_ACTION } from "./actions/builtin-actions.js";
 import * as BRSW2_CONFIG from "./brsw2-config.js";
-import { get_roll_options } from "./cards_common.js";
+import { getRollOptions } from "./cards_common.js";
 import { get_enabled_gm_actions } from "./gm_actions.js";
 import { check_for_actions_with_damage } from "./item_card.js";
 import {
@@ -43,7 +43,7 @@ export function registerActions() {
  * The array is cleared when reloading and should be set again
  * @param {Array} actions
  */
-function add_actions(actions) {
+function addActions(actions) {
     // Delete duplicate actions
     const actions_ids = actions.map((action) => action.id);
     const actions_to_delete = game.brsw.GLOBAL_ACTIONS.filter((action) =>
@@ -65,9 +65,9 @@ function process_not_selector(action, item, actor) {
 /**
  * Expose some functions to be used in macros.
  */
-export function expose_global_actions_functions() {
-    game.brsw.add_actions = add_actions;
-    game.brsw.get_roll_options = get_roll_options;
+export function exposeGlobalActionsAPI() {
+    Utils.exposeAPI("addActions", addActions, "add_actions");
+    Utils.exposeAPI("getRollOptions", getRollOptions, "get_roll_options");
 }
 
 /**

--- a/scripts/gm_actions.js
+++ b/scripts/gm_actions.js
@@ -7,7 +7,7 @@ import { SettingsUtils } from "./utils.js";
 /**
  * Sets up the hooks for the chat button
  */
-export function setup_chat_button() {
+export function setupChatButton() {
   if (!game.user.isGM) {
     return;
   }

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -76,7 +76,7 @@ function roll_incapacitation_clicked(ev, brCard) {
  * @param message Message date
  * @param html Html produced
  */
-export function activate_incapacitation_card_listeners(message, html) {
+export function activateIncapacitationCardListeners(message, html) {
     const brCard = new BrCommonCard(message);
     addEventListenerAll(html, ".brsw-vigor-button, .brsw-roll-button", "click", (ev) => {
         roll_incapacitation_clicked(ev, brCard);

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -14,7 +14,7 @@ import { Utils, addEventListenerAll } from "./utils.js";
 
 
 /**
- * Shows an incapacitation card an
+ * Shows an incapacitation card
  * @param {string} token_id As it comes from damage its target is always a token
  */
 export async function createIncapacitationCard(token_id) {

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -17,7 +17,7 @@ import { Utils, addEventListenerAll } from "./utils.js";
  * Shows an incapacitation card an
  * @param {string} token_id As it comes from damage its target is always a token
  */
-export async function create_incapacitation_card(token_id) {
+export async function createIncapacitationCard(token_id) {
     let token = canvas.tokens.get(token_id);
     let { actor } = token;
     let user = get_owner(actor);
@@ -51,10 +51,10 @@ export async function create_incapacitation_card(token_id) {
 /**
  * Hooks the public functions to a global object
  */
-export function incapacitation_card_hooks() {
-    game.brsw.create_incapacitation_card = create_incapacitation_card;
-    game.brsw.create_injury_card = create_injury_card;
-    game.brsw.create_injury_effect = create_injury_effect;
+export function exposeIncapacitationCardAPI() {
+    Utils.exposeAPI("createIncapacitationCard", createIncapacitationCard, "create_incapacitation_card");
+    Utils.exposeAPI("createInjuryCard", createInjuryCard, "create_injury_card");
+    Utils.exposeAPI("createInjuryEffect", createInjuryEffect, "create_injury_effect");
 }
 
 /**
@@ -84,7 +84,7 @@ export function activate_incapacitation_card_listeners(message, html) {
     html.querySelector(".brsw-injury-button")?.addEventListener("click", (ev) => {
         // noinspection JSIgnoredPromiseFromCall
         brCard.closePopout(); //We assume we're done with the card at this point so close any popouts
-        create_injury_card(
+        createInjuryCard(
             brCard.token_id,
             ev.currentTarget.dataset.injuryType,
         );
@@ -163,7 +163,7 @@ async function roll_incapacitation(brCard, spend_benny) {
  * @param token_id
  * @param {string} reason Reason for the injury
  */
-export async function create_injury_card(token_id, reason) {
+export async function createInjuryCard(token_id, reason) {
     let token = canvas.tokens.get(token_id);
     let { actor } = token;
     let user = get_owner(actor);
@@ -194,7 +194,7 @@ export async function create_injury_card(token_id, reason) {
             );
         }
     }
-    let injury_effect = await create_injury_effect(actor, reason, first_result, second_result);
+    let injury_effect = await createInjuryEffect(actor, reason, first_result, second_result);
     let brCard = await create_common_card(
         token,
         {
@@ -242,7 +242,7 @@ function read_table(table, value) {
  * @param {string} first_result The first result of an injury roll e.g. BRSW.Guts
  * @param {string} second_result The second result of an injury roll e.g. BRSW.Broken
  */
-export async function create_injury_effect(actor, reason, first_result, second_result) {
+export async function createInjuryEffect(actor, reason, first_result, second_result) {
     const active_effect_index = `${first_result}+${second_result}`;
     let new_effect;
     let injury_effect;

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -22,7 +22,7 @@ import {
     spend_bennie,
     update_message,
 } from "./cards_common.js";
-import { create_damage_card } from "./damage_card.js";
+import { createDamageCard } from "./damage_card.js";
 import { DamageModifier, TraitModifier } from "./modifiers.js";
 import { PPManagementDialog } from "./pp_management_dialog.js";
 import { calculateGangUp } from "./skill_card.js";
@@ -50,7 +50,7 @@ const ROF_BULLETS = { 1: 1, 2: 5, 3: 10, 4: 20, 5: 40, 6: 50 };
  * @return {Promise} A promise for the BrCommonCard object
  */
 // eslint-disable-next-line complexity
-export async function create_item_card(
+export async function createItemCard(
     origin,
     item_id,
     { actions_stored = {} } = {},
@@ -298,7 +298,7 @@ function call_create_item_card_hooks(item, brCard) {
  *   and a boolean meaning if they need to set on or off
  * @return {Promise} a promise for the BrCommonCard object
  */
-function create_item_card_from_id(
+function createItemCardFromId(
     token_id,
     actor_id,
     itemId,
@@ -314,7 +314,7 @@ function create_item_card_from_id(
     if (!origin && actor_id) {
         origin = game.actors.get(actor_id);
     }
-    return create_item_card(origin, itemId, {
+    return createItemCard(origin, itemId, {
         actions_stored: actions_stored,
     });
 }
@@ -322,11 +322,11 @@ function create_item_card_from_id(
 /**
  * Hooks the public functions to a global object
  */
-export function expose_item_functions() {
-    game.brsw.create_item_card = create_item_card;
-    game.brsw.create_item_card_from_id = create_item_card_from_id;
-    game.brsw.roll_item = roll_item;
-    game.brsw.create_damage_card = create_damage_card;
+export function exposeItemCardAPI() {
+    Utils.exposeAPI("createItemCard", createItemCard, "create_item_card");
+    Utils.exposeAPI("createItemCardFromId", createItemCardFromId, "create_item_card_from_id");
+    Utils.exposeAPI("rollItem", rollItem, "roll_item");
+    Utils.exposeAPI("createDamageCard", createDamageCard, "create_damage_card");
 }
 
 /**
@@ -382,13 +382,13 @@ async function item_click_listener(ev, target, currentTarget) {
         }
     }
     // Show card
-    const brCard = await create_item_card(target, item_id, {
+    const brCard = await createItemCard(target, item_id, {
         actions_stored: actions_stored,
     });
     if (action.includes("dialog")) {
         game.brsw.dialog.show_card(brCard);
     } else if (brCard.trait && action.includes("trait")) {
-        await roll_item(brCard, "", false, action.includes("damage"));
+        await rollItem(brCard, "", false, action.includes("damage"));
     } else if (brCard.damage && action.includes("damage")) {
         await roll_dmg(brCard, "");
     }
@@ -454,7 +454,7 @@ export function activate_item_card_listeners(brCard, html) {
 
     addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
         ev.stopPropagation();
-        await roll_item(
+        await rollItem(
             brCard,
             html,
             ev.currentTarget.classList.contains("roll-bennie-button"),
@@ -506,7 +506,7 @@ export function activate_item_card_listeners(brCard, html) {
     });
 
     addEventListenerAll(html, ".brsw-apply-damage", "click", (ev) => {
-        create_damage_card(
+        createDamageCard(
             ev.currentTarget.dataset.token,
             ev.currentTarget.dataset.damage,
             `${actor.name} - ${item.name}`,
@@ -835,7 +835,7 @@ async function findMacro(macro_name_or_id) {
  *
  * @return {Promise<void>}
  */
-export async function roll_item(brCard, html, expend_bennie, roll_damage) {
+export async function rollItem(brCard, html, expend_bennie, roll_damage) {
     const macros = [];
     let shots_override; // Override the number of shots used
     let shots_modifier = 0; // Modifier to the number of shots

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -605,7 +605,7 @@ async function roll_resist(trait, brCard, trait_mod) {
         if (BRSW2_CONST.ATTRIBUTES.includes(trait.toLowerCase())) {
             newCard = await game.brsw.createAttributeCard(token, trait.toLowerCase());
         } else {
-            newCard = await game.brsw.create_skill_card(token, Utils.traitFromString(token.actor, trait).id);
+            newCard = await game.brsw.createSkillCard(token, Utils.traitFromString(token.actor, trait).id);
         }
 
         newCard.trait_roll.tn = getTraitRollDifficulty(brCard);

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -13,7 +13,7 @@ import {
     check_and_roll_conviction,
     create_common_card,
     getActionFromClick,
-    get_roll_options,
+    getRollOptions,
     has_joker,
     process_common_actions,
     process_minimum_str_modifiers,
@@ -1401,7 +1401,7 @@ export async function roll_dmg(
     }
 
     // Calculate modifiers
-    const options = get_roll_options(default_options, brCard);
+    const options = getRollOptions(default_options, brCard);
 
     // Shotgun
     if (damageFormulas.damage?.includes("1-3d6") && item.type === "weapon") {

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -446,7 +446,7 @@ function preview_template(ev, brCard) {
  * @param {BrCommonCard} brCard
  * @param html Html produced
  */
-export function activate_item_card_listeners(brCard, html) {
+export function activateItemCardListeners(brCard, html) {
     const { actor, item } = brCard;
     html.querySelector(".brsw-header-img")?.addEventListener("click", (_) => {
         item.sheet.render(true);

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -93,7 +93,7 @@ export async function create_unstun_card(original_message, token_id) {
  * @param html Html produced
  * @param card_type Type of card
  */
-export function activate_remove_status_card_listeners(
+export function activateRemoveStatusCardListeners(
   brCard,
   html,
   card_type,

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -147,7 +147,7 @@ export function activate_skill_listeners(app, html) {
  * @param {BrCommonCard} brCard
  * @param html Html produced
  */
-export function activate_skill_card_listeners(brCard, html) {
+export function activateSkillCardListeners(brCard, html) {
     addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
         ev.stopPropagation();
         await rollSkill(

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -7,7 +7,7 @@ import { BRSW2_CONST } from "./brsw2-const.js";
 import {
     create_common_card,
     getActionFromClick,
-    get_actor_from_ids,
+    getActorFromIds,
     process_common_actions,
     roll_trait,
     spend_bennie,
@@ -32,7 +32,7 @@ import {
  * @param {SwadeActor} vehicle
  * @return {Promise} A promise for the ChatMessage object
  */
-async function create_skill_card(
+async function createSkillCard(
     origin,
     skillId,
     { actions_stored = {}, vehicle } = {},
@@ -68,23 +68,23 @@ async function create_skill_card(
 /**
  * Creates a skill card from a token or actor id, mainly for use in macros
  *
- * @param {string} token_id A token id, if it can be solved it will be used
+ * @param {string} tokenId A token id, if it can be solved it will be used
  *  before actor
- * @param {string} actor_id An actor id, it could be set as fallback or
+ * @param {string} actorId An actor id, it could be set as fallback or
  *  if you keep token empty as the only way to find the actor
  * @param {string} skillId Id of the skill item
  * @param {object} actions_stored An object with action ids as properties
  *   and a boolean meaning if they need to set on or off
  * @return {Promise} a promise for the ChatMessage object
  */
-function create_skill_card_from_id(
-    token_id,
-    actor_id,
+function createSkillCardFromId(
+    tokenId,
+    actorId,
     skillId,
     { actions_stored = {} } = {},
 ) {
-    const actor = get_actor_from_ids(token_id, actor_id);
-    return create_skill_card(actor, skillId, {
+    const actor = getActorFromIds(tokenId, actorId);
+    return createSkillCard(actor, skillId, {
         actions_stored: actions_stored,
     });
 }
@@ -92,10 +92,10 @@ function create_skill_card_from_id(
 /**
  * Hooks the public functions to a global object
  */
-export function skill_card_hooks() {
-    game.brsw.create_skill_card = create_skill_card;
-    game.brsw.create_skill_card_from_id = create_skill_card_from_id;
-    game.brsw.roll_skill = roll_skill;
+export function exposeSkillCardAPI() {
+    Utils.exposeAPI("createSkillCard", createSkillCard, "create_skill_card");
+    Utils.exposeAPI("createSkillCardFromId", createSkillCardFromId, "create_skill_card_from_id");
+    Utils.exposeAPI("rollSkill", rollSkill, "roll_skill");
 }
 
 /**
@@ -116,11 +116,11 @@ async function skill_click_listener(ev, target) {
         ev.currentTarget.parentElement.parentElement.dataset.itemId ||
         ev.currentTarget.parentElement.dataset.itemId;
     // Show card
-    const brCard = await create_skill_card(target, skillId);
+    const brCard = await createSkillCard(target, skillId);
     if (action.includes("dialog")) {
         game.brsw.dialog.show_card(brCard);
     } else if (action.includes("trait")) {
-        await roll_skill(brCard, false);
+        await rollSkill(brCard, false);
     }
 }
 
@@ -150,7 +150,7 @@ export function activate_skill_listeners(app, html) {
 export function activate_skill_card_listeners(brCard, html) {
     addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
         ev.stopPropagation();
-        await roll_skill(
+        await rollSkill(
             brCard,
             ev.currentTarget.classList.contains("roll-bennie-button"),
         );
@@ -168,7 +168,7 @@ export function activate_skill_card_listeners(brCard, html) {
  * @param {BrCommonCard} brCard
  * @param {boolean} expend_bennie True if we want to spend a bennie
  */
-export async function roll_skill(brCard, expend_bennie) {
+export async function rollSkill(brCard, expend_bennie) {
     const extra_data = { modifiers: [] };
     const macros = [];
     // Actions

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -313,15 +313,19 @@ export function measureDistance(tokenA, tokenB) {
 }
 
 export class Utils {
+    static warnedDeprecatedAPIs = new Set();
     static exposeAPI(name, fn, deprecatedName) {
         game.brsw[name] = fn;
 
         if (deprecatedName) {
             game.brsw[deprecatedName] = (...args) => {
-                foundry.utils.logCompatibilityWarning(
-                    `game.brsw.${deprecatedName} is deprecated. Use game.brsw.${name} instead.`,
-                    { since: "5.19.0" }
-                );
+                if (!Utils.warnedDeprecatedAPIs.has(deprecatedName)) {
+                    foundry.utils.logCompatibilityWarning(
+                        `game.brsw.${deprecatedName} is deprecated. Use game.brsw.${name} instead.`,
+                        { since: "5.19.0" }
+                    );
+                    Utils.warnedDeprecatedAPIs.add(deprecatedName);
+                }
                 return fn(...args);
             };
         }

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -313,6 +313,20 @@ export function measureDistance(tokenA, tokenB) {
 }
 
 export class Utils {
+    static exposeAPI(name, fn, deprecatedName) {
+        game.brsw[name] = fn;
+
+        if (deprecatedName) {
+            game.brsw[deprecatedName] = (...args) => {
+                foundry.utils.logCompatibilityWarning(
+                    `game.brsw.${deprecatedName} is deprecated. Use game.brsw.${name} instead.`,
+                    { since: "5.19.0" }
+                );
+                return fn(...args);
+            };
+        }
+    }
+
     //Compares lhs and rhs for equality
     //This pulls operators from rhs for the comparison or defaults to === if none is present
     static check_equality_with_operators(lhs, rhs) {

--- a/scripts/vehicle_card.js
+++ b/scripts/vehicle_card.js
@@ -3,7 +3,7 @@
 
 import { getActionFromClick } from "./cards_common.js";
 import { create_item_card } from "./item_card.js";
-import { roll_skill } from "./skill_card.js";
+import { rollSkill } from "./skill_card.js";
 import { Utils } from "./utils.js";
 
 /**
@@ -43,7 +43,7 @@ async function vehicle_click_listener(ev, vehicle) {
     }
 
     // Show card
-    const brCard = await game.brsw.create_skill_card(
+    const brCard = await game.brsw.createSkillCard(
         driverActor.actor,
         skill.id,
         {
@@ -53,7 +53,7 @@ async function vehicle_click_listener(ev, vehicle) {
     if (action.includes("dialog")) {
         game.brsw.dialog.show_card(brCard);
     } else if (action.includes("trait")) {
-        await roll_skill(brCard, false);
+        await rollSkill(brCard, false);
     }
 }
 

--- a/scripts/vehicle_card.js
+++ b/scripts/vehicle_card.js
@@ -2,7 +2,7 @@
 /* globals Token, game, ui, fromUuid, fromUuidSync */
 
 import { getActionFromClick } from "./cards_common.js";
-import { create_item_card } from "./item_card.js";
+import { createItemCard } from "./item_card.js";
 import { rollSkill } from "./skill_card.js";
 import { Utils } from "./utils.js";
 
@@ -73,7 +73,7 @@ function vehicle_weapon_clicked(ev, vehicle) {
     }
 
     if (gunner) {
-        create_item_card(gunner, item.uuid);
+        createItemCard(gunner, item.uuid);
     } else {
         ui.notifications.error("BRSW.NoGunner");
     }


### PR DESCRIPTION
## Summary by Sourcery

Standardize and modernize the public BR2 API and listeners while preserving backward compatibility through a shared exposure helper.

New Features:
- Introduce a Utils.exposeAPI helper to register public APIs and emit deprecation warnings for legacy names.

Enhancements:
- Rename and align public API methods and listener functions to camelCase across cards, damage, incapacitation, and global actions.
- Expose card-creation and roll APIs via Utils.exposeAPI instead of direct game.brsw assignments, centralizing deprecation handling.
- Clarify and harden BrCommonCard.item access by safely handling missing actors.
- Update documentation and changelog to reflect the new camelCase API surface and corrected examples.

Documentation:
- Refresh API documentation to use the new camelCase method names and fix minor wording issues.