### PR TITLE
Pp man

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Version 5.20.0
 * Improved damage row display
 * Removed Tailwind
+* Fixed selection of PP mods when there are multiple with the same name e.g. Area of Effect (+2/+3)
 
 # Version 5.19.0
 * Improved chat popout handling

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -194,14 +194,13 @@ function get_pp_mods(item) {
     if (modifiers.length) {
         for (let mod of modifiers) {
             for (let cost of mod.costs) {
-                if (cost !== "+0") {
-                    pp_mods.powerMods.push({
-                        name: Utils.toTitleCase(mod.name),
-                        cost: cost,
-                        isEpic: mod.isEpic,
-                        selected: false,
-                    });
-                }
+                pp_mods.powerMods.push({
+                    name: Utils.toTitleCase(mod.name),
+                    cost: cost,
+                    isEpic: mod.isEpic,
+                    selected: false,
+                    exclusiveGroup: mod.costs.length > 1 ? mod.name : undefined,
+                });
             }
         }
 

--- a/scripts/pp_management_dialog.js
+++ b/scripts/pp_management_dialog.js
@@ -21,7 +21,8 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
         const isGeneric = button.closest("div").getAttribute("name") === "generic-mods";
         const mods = isGeneric ? this.brCard.pp_modifiers.genericMods : this.brCard.pp_modifiers.powerMods;
         const modName = button.dataset.modname;
-        const mod = mods.find(m => m.name == modName);
+        const modCost = button.dataset.modcost;
+        const mod = mods.find(m => m.name === modName && m.cost === modCost);
 
         if (mod.exclusiveGroup) {
           const groupMods = mods.filter(m => m != mod && m.exclusiveGroup === mod.exclusiveGroup);
@@ -206,7 +207,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
   }
 
   selectMod(mod, isGeneric) {
-    const button = this.element.querySelector(`[data-modName="${mod.name}"`);
+    const button = this.element.querySelector(`[data-modName="${mod.name}"][data-modCost="${mod.cost}"]`);
     button.classList.add("selected");
     if (isGeneric) {
       if (mod.actionId) {
@@ -225,7 +226,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
   }
 
   deselectMod(mod, isGeneric) {
-    const button = this.element.querySelector(`[data-modName="${mod.name}"`);
+    const button = this.element.querySelector(`[data-modName="${mod.name}"][data-modCost="${mod.cost}"]`);
     button.classList.remove("selected");
     if (isGeneric) {
       if (mod.actionId) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -358,8 +358,25 @@ export class Utils {
         }[op];
     }
 
+    //Converts a string to headline case
     static toTitleCase(str) {
-        return str.toLowerCase().replace(/\b\w/g, c => c.toUpperCase());
+        const minorWords = new Set([
+            "a", "an", "the",
+            "and", "but", "or", "nor",
+            "as", "at", "by", "for", "from",
+            "in", "into", "of", "on", "onto",
+            "per", "to", "up", "via", "with"
+        ]);
+
+        return str
+            .toLowerCase()
+            .split(/\s+/)
+            .map((word, index, words) => {
+                if (index !== 0 && index !== words.length - 1 && minorWords.has(word)) {
+                    return word;
+                }
+                return word.charAt(0).toUpperCase() + word.slice(1);
+            }).join(" ");
     }
 
     static forEachActionGroup(brCard, callbackFn) {

--- a/templates/pp_management_dialog.hbs
+++ b/templates/pp_management_dialog.hbs
@@ -3,7 +3,7 @@
         <legend>{{{localize "BRSW.PPManagement.GenericMods"}}}</legend>
         <div class="pp-mod-selection" name="generic-mods">
             {{#each genericMods}}
-                <button class="pp-mod {{#if selected}}selected{{/if}}" type="button" data-action="toggleMod" data-modName="{{name}}">
+                <button class="pp-mod {{#if selected}}selected{{/if}}" type="button" data-action="toggleMod" data-modName="{{name}}" data-modCost="{{cost}}">
                     {{{localize name}}} [{{cost}}PP]
                 </button>
             {{/each}}
@@ -14,7 +14,7 @@
             <legend>{{localize "BRSW.PPManagement.PowerMods"}}</legend>
             <div class="pp-mod-selection" name="power-mods">
                 {{#each powerMods}}
-                    <button class="pp-mod {{#if selected}}selected{{/if}}" type="button" data-action="toggleMod" data-modName="{{name}}">
+                    <button class="pp-mod {{#if selected}}selected{{/if}}" type="button" data-action="toggleMod" data-modName="{{name}}" data-modCost="{{cost}}">
                         {{#if isEpic}}<i class="fas fa-star" style="color: #db8f26;"></i>{{/if}}{{name}} [{{cost}}PP]
                     </button>
                 {{/each}}


### PR DESCRIPTION
## Summary by Sourcery

Improve PP modifier selection and exclusivity handling when multiple costs exist for the same modifier name, and enhance title casing behavior for displayed modifier names.

New Features:
- Support headline-style title casing that keeps minor words lowercased except at the beginning or end of a string.

Bug Fixes:
- Ensure PP modifiers can be uniquely selected and toggled when multiple modifiers share the same name but have different costs.

Enhancements:
- Group mutually exclusive PP power modifiers by name when they have multiple cost options to support correct exclusivity behavior in the UI.

Documentation:
- Update changelog to document the PP modifier selection fix for multi-cost modifiers.