### PR TITLE
Header tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+# Version 5.21.0
+* We now hide various header tools on certain cards
+
 # Version 5.20.1
 * Fixed some issues with the damage row
 

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -2,14 +2,14 @@
 /* globals game, ChatPopout, console, canvas, Hooks, renderTemplate, TextEditor, ChatMessage,
      Roll, CONST */
 
+import { brAction } from "./actions.js";
 import * as BRSW2_CONFIG from "./brsw2-config.js";
+import { BRSW2_CONST } from "./brsw2-const.js";
+import { are_bennies_available, traitToDieString } from "./cards_common.js";
+import { get_actions, process_action } from "./global_actions.js";
+import { calc_pp_cost } from "./item_card.js";
 import { TraitRoll } from "./rolls.js";
 import { broofa, getAuthor, getWhisperData, SettingsUtils, Utils } from "./utils.js";
-import { calc_pp_cost } from "./item_card.js";
-import { get_actions, process_action } from "./global_actions.js";
-import { brAction } from "./actions.js";
-import { are_bennies_available, traitToDieString } from "./cards_common.js";
-import { BRSW2_CONST } from "./brsw2-const.js";
 
 /**
  * Stores a flag with the render data, deletes data can't be stored
@@ -950,7 +950,10 @@ export class BrCommonCard {
         data.selected_actions = this.getSelectedActions();
         data.hasFooterButtons = this.hasFooterButtons;
         data.skill_tooltip = this.skill_tooltip;
-        data.supports_manual_mods = !!(this.trait || this.damage);
+        data.showRepeat = BRSW2_CONST.ALLOW_SAVE_REPEAT_CARDS.has(this.type);
+        data.showSave = !this.vehicle_actor && BRSW2_CONST.ALLOW_SAVE_REPEAT_CARDS.has(this.type);
+        data.showManualMods = !!(this.trait || this.damage);
+        data.showTools = data.showRepeat || data.showSave || data.showManualMods;
         data.noPowerPoints = game.settings.get("swade", "noPowerPoints");
         data.ppPenalty = -Math.ceil(this.pp_cost / 2);
         data.shots_pp_info = this.itemShots;

--- a/scripts/brsw2-const.js
+++ b/scripts/brsw2-const.js
@@ -180,4 +180,10 @@ export class BRSW2_CONST {
         [-4]: "BRSW.RangeLong",
         [-8]: "BRSW.RangeExtreme",
     };
+
+    static ALLOW_SAVE_REPEAT_CARDS = new Set([
+        BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD,
+        BRSW2_CONST.BRSW_CARD_TYPES.TYPE_SKILL_CARD,
+        BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ITEM_CARD,
+    ]);
 }

--- a/templates/common_card_header.hbs
+++ b/templates/common_card_header.hbs
@@ -10,15 +10,19 @@
     <div class="brsw-header-title-wrapper">
         <span class="brsw-header-title-group">
             <a class="brsw-collapse-button brsw-header-title" data-collapse="brsw-description">{{header.title}}</a>
-            <span class="brsw-common-tools brsw-form">
-                <i class="brsw-repeat-card brsw-common-tool fas fa-redo"></i>
-                {{#unless vehicle_actor}}
-                    <i class="brsw-owner-trusted-only brsw-save-macro brsw-common-tool fa fa-save"></i>
-                {{/unless}}
-                {{#if supports_manual_mods}}
-                    <i class="brsw-manual-mods brsw-common-tool fas fa-plus-minus"></i>
-                {{/if}}
-            </span>
+            {{#if showTools}}
+                <span class="brsw-common-tools brsw-form">
+                    {{#if showRepeat}}
+                        <i class="brsw-repeat-card brsw-common-tool fas fa-redo"></i>
+                    {{/if}}
+                    {{#if showSave}}
+                        <i class="brsw-owner-trusted-only brsw-save-macro brsw-common-tool fa fa-save"></i>
+                    {{/if}}
+                    {{#if showManualMods}}
+                        <i class="brsw-manual-mods brsw-common-tool fas fa-plus-minus"></i>
+                    {{/if}}
+                </span>
+            {{/if}}
             {{#if tooltip}}
                 <div id="tooltip-description" role="tooltip" class="brsw-tooltip">
                     {{{tooltip}}}


### PR DESCRIPTION
## Summary by Sourcery

Gate card header tools behind card-type specific visibility flags.

New Features:
- Add per-card-type configuration to control visibility of repeat and save header tools.

Enhancements:
- Show or hide header tool icons in the common card header template based on new visibility flags.
- Introduce a shared constant listing card types that allow save and repeat tools, and wire it into common card rendering logic.

Documentation:
- Document the header tools visibility change in the changelog.