### PR TITLE
Cleaned up the soak modifiers

### DIFF
--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -9,7 +9,7 @@ import {
   getActorFromIds,
   process_common_actions,
   roll_trait,
-  spend_bennie,
+  spendBenny,
   traitToDieString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
@@ -148,7 +148,7 @@ export async function rollAttribute(brCard, expend_bennie) {
     brCard.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
   }
   if (expend_bennie) {
-    await spend_bennie(brCard.actor);
+    await spendBenny(brCard.actor);
   }
   await roll_trait(
     brCard,

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -33,7 +33,7 @@ import {
     getTargetedToken,
     set_or_update_condition,
     simple_form,
-    spendMastersBenny,
+    spendGMBenny,
 } from "./utils.js";
 
 /**
@@ -111,17 +111,14 @@ export function are_bennies_available(actor) {
  * Expends a bennie
  * @param {SwadeActor} actor - Actor who is going to expend the bennie
  */
-export async function spend_bennie(actor) {
-    // Dice so Nice animation
-    if (actor.hasPlayerOwner) {
-        await actor.spendBenny();
-    } else if (actor.system.wildcard && actor.system.bennies.value > 0) {
+export async function spendBenny(actor) {
+    // Dice So Nice animation
+    if (actor.hasPlayerOwner || (actor.system.wildcard && actor.system.bennies.value > 0)) {
         await actor.spendBenny();
     } else {
-        await spendMastersBenny();
+        await spendGMBenny();
         if (game.dice3d) {
             const benny = await new Roll("1dB").roll();
-            // noinspection JSIgnoredPromiseFromCall,ES6MissingAwait
             game.dice3d.showForRoll(benny, game.user, true, null, false);
         }
     }

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -6,7 +6,7 @@ import {
     are_bennies_available,
     create_common_card,
     roll_trait,
-    spend_bennie,
+    spendBenny,
 } from "./cards_common.js";
 import {
     createIncapacitationCard,
@@ -221,14 +221,14 @@ export function activateDamageCardListeners(message, html) {
     });
     addEventListenerAll(html, ".brsw-soak-button, .brsw-roll-button", "click", (ev) => {
         ev.stopPropagation();
-        let spend_bennie = false;
+        let spendBenny = false;
         if (
             ev.currentTarget.classList.contains("roll-bennie-button") ||
             ev.currentTarget.classList.contains("brsw-soak-button")
         ) {
-            spend_bennie = true;
+            spendBenny = true;
         }
-        roll_soak(brCard, spend_bennie);
+        rollSoak(brCard, spendBenny);
     });
     html.querySelector(".brsw-show-incapacitation")?.addEventListener("click", () => {
         brCard.closePopout(); //We assume we're done with the card at this point so close any popouts
@@ -247,65 +247,48 @@ export function activateDamageCardListeners(message, html) {
 /**
  * Males a soak roll
  * @param {BrCommonCard} brCard
- * @param {Boolean} use_bennie
+ * @param {Boolean} useBenny
  */
-async function roll_soak(brCard, use_bennie) {
-    if (use_bennie) {
-        await spend_bennie(brCard.actor);
+async function rollSoak(brCard, useBenny) {
+    if (useBenny) {
+        await spendBenny(brCard.actor);
     }
 
-    let undo_wound_modifier = Math.min(brCard.actor.system.wounds.value, 3) - brCard.render_data.undo_values.wounds;
+    const wounds = Math.min(brCard.actor.system.wounds.value, 3);
+    const ignoredWounds = parseInt(brCard.actor.system.wounds.ignored) + (parseInt(brCard.actor.system.woundsOrFatigue.ignored) || 0);
 
-    const ignored_wounds = parseInt(brCard.actor.system.wounds.ignored) + (parseInt(brCard.actor.system.woundsOrFatigue.ignored) || 0);
+    const undoWounds = brCard.render_data.undo_values.wounds;
+    const undoWoundModifier = ignoredWounds ? Math.max(0, wounds - Math.max(ignoredWounds, undoWounds)) : wounds - undoWounds;
 
-    if (ignored_wounds) {
-        undo_wound_modifier = Math.max(
-            0,
-            Math.min(brCard.actor.system.wounds.value, 3) - ignored_wounds - Math.max(0, brCard.render_data.undo_values.wounds - ignored_wounds),
-        );
-    }
+    const soakModifiers = [];
 
-    const soak_modifiers = [
-        {
-            name: game.i18n.localize("BRSW.RemoveWounds"),
-            value: undo_wound_modifier,
-        },
-    ];
-
-    if (
-        brCard.actor.items.find((item) => {
-            return (
-                item.type === "edge" &&
-                item.name.toLowerCase().includes(game.i18n.localize("BRSW.EdgeName.IronJaw").toLowerCase())
-            );
-        })
-    ) {
-        soak_modifiers.push({ name: game.i18n.localize("BRSW.EdgeName.IronJaw"), value: 2 });
+    if (undoWoundModifier > 0) {
+        soakModifiers.push({ name: game.i18n.localize("BRSW.RemoveWounds"), value: undoWoundModifier });
     }
 
     // Active effects
-    const soak_active_effects = brCard.actor.appliedEffects.filter((e) =>
+    const soakActiveEffects = brCard.actor.appliedEffects.filter((e) =>
         e.changes.find((ch) => ch.key === "brsw.soak-modifier" || ch.key === "system.attributes.vigor.soakBonus")
     );
 
-    for (const effect of soak_active_effects) {
+    for (const effect of soakActiveEffects) {
         const change =
             effect.changes.find((ch) => ch.key === "brsw.soak-modifier") ||
             effect.changes.find((ch) => ch.key === "system.attributes.vigor.soakBonus");
 
-        soak_modifiers.push({ name: effect.label, value: parseInt(change.value) });
+        soakModifiers.push({ name: effect.name, value: parseInt(change.value) });
     }
 
     // Unarmored hero
     if (game.settings.get("swade", "unarmoredHero") && brCard.actor.isUnarmored) {
-        soak_modifiers.push({ name: game.i18n.localize("BRSW.UnarmoredHero"), value: 2 });
+        soakModifiers.push({ name: game.i18n.localize("BRSW.UnarmoredHero"), value: 2 });
     }
 
     await roll_trait(
         brCard,
         brCard.actor.system.attributes.vigor,
         game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS.vigor),
-        { modifiers: soak_modifiers },
+        { modifiers: soakModifiers },
     );
 
     let result = 0;

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -7,7 +7,7 @@ import { BRSW2_CONST } from "./brsw2-const.js";
 import {
     create_common_card,
     roll_trait,
-    spend_bennie,
+    spendBenny,
 } from "./cards_common.js";
 import { get_owner } from "./damage_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
@@ -62,12 +62,12 @@ export function exposeIncapacitationCardAPI() {
  */
 function roll_incapacitation_clicked(ev, brCard) {
     ev.stopPropagation();
-    let spend_bennie = false;
+    let spendBenny = false;
     if (ev.currentTarget.classList.contains("roll-bennie-button")) {
-        spend_bennie = true;
+        spendBenny = true;
     }
     // noinspection JSIgnoredPromiseFromCall
-    roll_incapacitation(brCard, spend_bennie);
+    roll_incapacitation(brCard, spendBenny);
 }
 
 /**
@@ -97,7 +97,7 @@ export function activateIncapacitationCardListeners(message, html) {
  */
 async function roll_incapacitation(brCard, spend_benny) {
     if (spend_benny) {
-        await spend_bennie(brCard.actor);
+        await spendBenny(brCard.actor);
     }
     await roll_trait(
         brCard,

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -19,7 +19,7 @@ import {
     process_minimum_str_modifiers,
     roll_dice,
     roll_trait,
-    spend_bennie,
+    spendBenny,
     update_message,
 } from "./cards_common.js";
 import { createDamageCard } from "./damage_card.js";
@@ -842,7 +842,7 @@ export async function rollItem(brCard, html, expend_bennie, roll_damage) {
     }
 
     if (expend_bennie) {
-        await spend_bennie(brCard.actor);
+        await spendBenny(brCard.actor);
     }
 
     extra_data.rof = brCard.item.system.rof || 1;
@@ -1394,7 +1394,7 @@ export async function roll_dmg(
 
     const macros = [];
     if (expend_bennie) {
-        await spend_bennie(actor);
+        await spendBenny(actor);
     }
 
     // Calculate modifiers

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -7,7 +7,7 @@ import { BRSW2_CONST } from "./brsw2-const.js";
 import {
   create_common_card,
   roll_trait,
-  spend_bennie,
+  spendBenny,
 } from "./cards_common.js";
 import { get_owner } from "./damage_card.js";
 import { TraitModifier } from "./modifiers.js";
@@ -101,15 +101,15 @@ export function activateRemoveStatusCardListeners(
     card_type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_UNSHAKE_CARD ? roll_unshaken : roll_unstun;
   addEventListenerAll(html, ".brsw-spirit-button, .brsw-roll-button", "click", (ev) => {
     ev.stopPropagation();
-    let spend_bennie = false;
+    let spendBenny = false;
     if (
       ev.currentTarget.classList.contains("roll-bennie-button") ||
       ev.currentTarget.classList.contains("brsw-soak-button")
     ) {
-      spend_bennie = true;
+      spendBenny = true;
     }
     // noinspection JSIgnoredPromiseFromCall
-    roll_function(brCard, spend_bennie);
+    roll_function(brCard, spendBenny);
   });
 }
 
@@ -121,7 +121,7 @@ export function activateRemoveStatusCardListeners(
 async function roll_unshaken(brCard, use_bennie) {
   if (use_bennie) {
     // remove shaken
-    await spend_bennie(brCard.actor);
+    await spendBenny(brCard.actor);
     brCard.render_data.text = game.i18n.format("BRSW.UnshakeBennie", {
       name: brCard.actor.name,
     });

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -8,7 +8,7 @@ import {
     getActorFromIds,
     process_common_actions,
     roll_trait,
-    spend_bennie,
+    spendBenny,
     traitToDieString,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
@@ -176,7 +176,7 @@ export async function rollSkill(brCard, expend_bennie) {
         brCard.trait_roll.reroll_mode = expend_bennie ? "benny" : "free";
     }
     if (expend_bennie) {
-        await spend_bennie(brCard.actor);
+        await spendBenny(brCard.actor);
     }
     await roll_trait(
         brCard,

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -76,9 +76,8 @@ export function makeExplodable(expression) {
     );
 }
 
-export async function spendMastersBenny() {
-    // Spends one benny from the gamemaster stack
-    // noinspection ES6MissingAwait
+export async function spendGMBenny() {
+    // Spends one benny from the GM stack
     for (const user of game.users) {
         if (user.isGM) {
             const value = user.getFlag("swade", "bennies");


### PR DESCRIPTION
## Summary by Sourcery

Standardize bennie utility naming and adjust soak modifier calculation based on wounds and ignored wounds.

Enhancements:
- Rename bennie-related helper functions and parameters to consistent camelCase forms across cards and utilities.
- Refine soak roll modifiers to correctly account for current wounds and ignored wounds before rolling vigor.
- Update GM bennie spending helper to use a clearer name while preserving behavior.