### PR TITLE
Dark mode

### DIFF
--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -5,6 +5,7 @@
 
     --brsw-color-gray-200: oklch(0.928 0.006 264.531);
     --brsw-color-gray-300: oklch(0.872 0.01 258.338);
+    --brsw-color-gray-400: oklch(0.709 0.019 261.351);
     --brsw-color-gray-500: oklch(0.551 0.027 264.364);
     --brsw-color-gray-600: oklch(0.446 0.03 256.802);
     --brsw-color-gray-700: oklch(0.373 0.034 259.733);
@@ -17,7 +18,14 @@
     --brsw-color-red-border: oklch(0.577 0.245 27.325);
     --brsw-color-red-hover: oklch(0.396 0.141 25.723);
 
+    --brsw-color-blue: blue;
+
     --brsw-color-selected-tag-text: #ffe2dc;
+
+    --brsw-button-bg-color: white;
+
+    --brsw-card-note-warning-color: #FF6467;
+    --brsw-card-note-bg-color: var(--brsw-color-gray-800);
 
     --brsw-text-xs: 0.75rem;
     --brsw-text-xs-line-height: 1rem;
@@ -35,6 +43,51 @@
 
     --brsw-transition-duration: 150ms;
     --brsw-transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.themed.theme-dark {
+    --brsw-chat-message-color: var(--color-light-2);
+    --brsw-button-bg-color: var(--color-light-2);
+    --brsw-color-blue: rgb(47, 137, 255);
+    --brsw-card-note-warning-color: #ff393d;
+    --brsw-card-note-bg-color: var(--brsw-color-gray-700);
+}
+
+.themed.theme-dark .brsw-chat-message {
+    color: var(--brsw-chat-message-color);
+    isolation: isolate;
+}
+
+.themed.theme-dark .brsw-chat-message:not(.blind):not(.whisper) {
+    position: relative;
+    background: none;
+}
+
+.themed.theme-dark .brsw-chat-message:not(.blind):not(.whisper)::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url("/ui/parchment.jpg");
+    filter: brightness(40%) contrast(250%);
+    z-index: 0;
+    pointer-events: none;
+}
+
+.themed.theme-dark .brsw-chat-message > * {
+    position: relative;
+    z-index: 1;
+}
+
+.themed.theme-dark .brsw-chat-message.blind {
+    background: #4b294b;
+}
+
+.themed.theme-dark .brsw-chat-message.whisper:not(.blind) {
+    background: #3e3e4f;
+}
+
+.themed.theme-dark .brsw-chat-message .message-header {
+    color: var(--brsw-chat-message-color);
 }
 
 /* General Styles */
@@ -349,6 +402,22 @@
     margin-left: 2px;
 }
 
+.themed.theme-dark .brsw-dice-image {
+    position: relative;
+    -webkit-text-stroke: 2px black;
+}
+
+.themed.theme-dark .brsw-dice-image::before {
+    content: attr(data-text);
+    text-align: center;
+    align-content: center;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    -webkit-text-stroke: 0;
+    color: var(--brsw-chat-message-color);
+}
+
 .brsw-button-image {
     border: none;
     vertical-align: text-bottom;
@@ -371,7 +440,7 @@
 }
 
 .brsw-blue-text {
-    color: blue !important;
+    color: var(--brsw-color-blue);
 }
 
 .brsw-green-text {
@@ -487,6 +556,20 @@
 
     display: flex;
     flex-direction: column;
+}
+
+.themed.theme-dark #br-card-dialog {
+    position: relative;
+    background: none;
+}
+
+.themed.theme-dark #br-card-dialog::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: url("/ui/parchment.jpg");
+    filter: brightness(15%);
+    z-index: -1;
 }
 
 #br-card-dialog > div {
@@ -643,7 +726,7 @@
     font-weight: bold;
     border-style: none;
     margin: calc(var(--brsw-spacing) * 2);
-    color: black;
+    color: var(--brsw-chat-message-color);
 }
 
 .brsw-dialog-close-btn {
@@ -710,7 +793,7 @@
     margin-right: calc(var(--brsw-spacing) * 2);
     margin-bottom: calc(var(--brsw-spacing) * 2);
     font-weight: var(--brsw-font-weight-medium);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -879,11 +962,11 @@
     font-size: var(--brsw-text-sm);
     line-height: var(--brsw-text-sm-line-height);
     border-radius: var(--brsw-radius-lg);
-    background-color: var(--brsw-color-gray-800);
+    background-color: var(--brsw-card-note-bg-color);
 }
 
 .brsw-card-note-warning {
-    color: #FF6467;
+    color: var(--brsw-card-note-warning-color);
 }
 
 .brsw-card-note-extra {
@@ -901,7 +984,7 @@
 .brsw-undo-damage {
     margin-top: calc(var(--brsw-spacing) * 2);
     padding: calc(var(--brsw-spacing) * 0.5);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -924,7 +1007,7 @@
 .brsw-full-button {
     padding-block: calc(var(--brsw-spacing) * 0.5);
     padding-inline: calc(var(--brsw-spacing) * 5);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -961,6 +1044,7 @@
 
 .brsw-damage-roll-damage > span {
     min-width: 2em;
+    min-height: 2em;
     text-align: center;
     align-content: center;
     min-height: stretch;
@@ -968,6 +1052,31 @@
     background-repeat: no-repeat;
     background-position: center;
     background-image: url("/icons/svg/combat.svg");
+}
+
+.themed.theme-dark .brsw-damage-roll-damage > span {
+    background-image: none;
+    position: relative;
+}
+
+.themed.theme-dark .brsw-damage-roll-damage > span::after {
+    content: attr(data-text);
+    text-align: center;
+    align-content: center;
+    position: absolute;
+    inset: 0;
+    color: black;
+    z-index: -1;
+    -webkit-text-stroke: 2px black;
+}
+
+.themed.theme-dark .brsw-damage-roll-damage > span::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-color: rgb(141,141,141);
+    mask: url("/icons/svg/combat.svg") center / 2em 2em no-repeat;
+    z-index: -1;
 }
 
 .brsw-damage-roll-result {
@@ -1008,7 +1117,7 @@
 }
 
 .brsw-shaken-result {
-    color: blue;
+    color: var(--brsw-color-blue);
 }
 
 .brsw-result-icon {
@@ -1019,7 +1128,7 @@
 
 .brsw-icon-button {
     padding: calc(var(--brsw-spacing) * 0.5);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -1091,7 +1200,7 @@
     padding-block: calc(var(--brsw-spacing) * 0.5);
     padding-inline: var(--brsw-spacing);
     font-weight: var(--brsw-font-weight-medium);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -1109,7 +1218,7 @@
     padding-inline: calc(var(--brsw-spacing) * 5);
     margin-top: calc(var(--brsw-spacing) * 2);
     font-weight: var(--brsw-font-weight-medium);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);
@@ -1254,7 +1363,7 @@
 .brsw-item-button {
     padding-block: calc(var(--brsw-spacing) * 0.5);
     font-weight: var(--brsw-font-weight-medium);
-    background-color: white;
+    background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
     color: var(--brsw-color-gray-800);

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -45,7 +45,7 @@
     --brsw-transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.themed.theme-dark {
+.themed.theme-dark .brsw-allow-dark-mode {
     --brsw-chat-message-color: var(--color-light-2);
     --brsw-button-bg-color: var(--color-light-2);
     --brsw-color-blue: rgb(47, 137, 255);
@@ -53,17 +53,17 @@
     --brsw-card-note-bg-color: var(--brsw-color-gray-700);
 }
 
-.themed.theme-dark .brsw-chat-message {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message {
     color: var(--brsw-chat-message-color);
     isolation: isolate;
 }
 
-.themed.theme-dark .brsw-chat-message:not(.blind):not(.whisper) {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message:not(.blind):not(.whisper) {
     position: relative;
     background: none;
 }
 
-.themed.theme-dark .brsw-chat-message:not(.blind):not(.whisper)::before {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message:not(.blind):not(.whisper)::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -73,20 +73,20 @@
     pointer-events: none;
 }
 
-.themed.theme-dark .brsw-chat-message > * {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message > * {
     position: relative;
     z-index: 1;
 }
 
-.themed.theme-dark .brsw-chat-message.blind {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message.blind {
     background: #4b294b;
 }
 
-.themed.theme-dark .brsw-chat-message.whisper:not(.blind) {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message.whisper:not(.blind) {
     background: #3e3e4f;
 }
 
-.themed.theme-dark .brsw-chat-message .message-header {
+.themed.theme-dark .brsw-allow-dark-mode.brsw-chat-message .message-header {
     color: var(--brsw-chat-message-color);
 }
 
@@ -402,12 +402,12 @@
     margin-left: 2px;
 }
 
-.themed.theme-dark .brsw-dice-image {
+.themed.theme-dark .brsw-allow-dark-mode .brsw-dice-image {
     position: relative;
     -webkit-text-stroke: 2px black;
 }
 
-.themed.theme-dark .brsw-dice-image::before {
+.themed.theme-dark .brsw-allow-dark-mode .brsw-dice-image::before {
     content: attr(data-text);
     text-align: center;
     align-content: center;
@@ -558,12 +558,12 @@
     flex-direction: column;
 }
 
-.themed.theme-dark #br-card-dialog {
+.themed.theme-dark .brsw-allow-dark-mode #br-card-dialog {
     position: relative;
     background: none;
 }
 
-.themed.theme-dark #br-card-dialog::before {
+.themed.theme-dark .brsw-allow-dark-mode #br-card-dialog::before {
     content: "";
     position: absolute;
     inset: 0;
@@ -1054,12 +1054,12 @@
     background-image: url("/icons/svg/combat.svg");
 }
 
-.themed.theme-dark .brsw-damage-roll-damage > span {
+.themed.theme-dark .brsw-allow-dark-mode .brsw-damage-roll-damage > span {
     background-image: none;
     position: relative;
 }
 
-.themed.theme-dark .brsw-damage-roll-damage > span::after {
+.themed.theme-dark .brsw-allow-dark-mode .brsw-damage-roll-damage > span::after {
     content: attr(data-text);
     text-align: center;
     align-content: center;
@@ -1070,7 +1070,7 @@
     -webkit-text-stroke: 2px black;
 }
 
-.themed.theme-dark .brsw-damage-roll-damage > span::before {
+.themed.theme-dark .brsw-allow-dark-mode .brsw-damage-roll-damage > span::before {
     content: "";
     position: absolute;
     inset: 0;

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -47,7 +47,8 @@
 
 .themed.theme-dark .brsw-allow-dark-mode {
     --brsw-chat-message-color: var(--color-light-2);
-    --brsw-button-bg-color: var(--color-light-2);
+    --brsw-button-bg-color: var(--color-cool-5-50);
+    --brsw-button-color: var(--color-light-3);
     --brsw-color-blue: rgb(47, 137, 255);
     --brsw-card-note-warning-color: #ff393d;
     --brsw-card-note-bg-color: var(--brsw-color-gray-700);
@@ -794,9 +795,9 @@
     margin-bottom: calc(var(--brsw-spacing) * 2);
     font-weight: var(--brsw-font-weight-medium);
     background-color: var(--brsw-button-bg-color);
+    color: var(--brsw-button-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
     width: 100%;
 }
 
@@ -987,7 +988,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
 }
 
 .brsw-undo-damage:hover {
@@ -1010,7 +1011,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
     width: 100%;
 }
 
@@ -1074,7 +1075,7 @@
     content: "";
     position: absolute;
     inset: 0;
-    background-color: rgb(141,141,141);
+    background-color: #40404a;
     mask: url("/icons/svg/combat.svg") center / 2em 2em no-repeat;
     z-index: -1;
 }
@@ -1107,8 +1108,8 @@
 }
 
 .brsw-apply-damage:not(:disabled) {
-    background: white;
-    color: var(--brsw-color-gray-800);
+    background-color: var(--brsw-button-bg-color);
+    color: var(--brsw-button-color);
 }
 
 .brsw-apply-damage:not(:disabled):hover {
@@ -1131,7 +1132,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
 }
 
 .brsw-icon-button:hover {
@@ -1203,7 +1204,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
 }
 
 .brsw-reroll-button:hover {
@@ -1221,7 +1222,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
 }
 
 .brsw-footer-button:hover {
@@ -1366,7 +1367,7 @@
     background-color: var(--brsw-button-bg-color);
     border-radius: var(--brsw-radius-lg);
     border: 1px solid var(--brsw-color-gray-600);
-    color: var(--brsw-color-gray-800);
+    color: var(--brsw-button-color);
     width: 100%;
     text-wrap-mode: nowrap;
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -327,6 +327,8 @@
   "BRSW.Save": "Save",
   "BRSW.Scale": "Scale",
   "BRSW.Scar": "Hideous scar",
+  "BRSW.Settings.AllowDarkMode.Hint": "If disabled, Better Rolls will always use Light Mode regardless of Foundry settings",
+  "BRSW.Settings.AllowDarkMode.Name": "Allow Dark Mode",
   "BRSW.Settings.AltClickAction.Hint": "Select what happens when you click a name while pressing Alt",
   "BRSW.Settings.AltClickAction.Name": "Alt Click",
   "BRSW.Settings.AmmoManagement.Hint": "When marked Subtract ammo will be selected by default",

--- a/scripts/brsw2-config.js
+++ b/scripts/brsw2-config.js
@@ -45,6 +45,7 @@ export const WORLD_SETTING_KEYS = {
 };
 
 export const USER_SETTING_KEYS = {
+    allowDarkMode: "allowDarkMode",
     autoPopoutChat: "auto_popout_chat",
     defaultRateOfFire: "default_rate_of_fire",
     expandDescriptions: "expand-descriptions",

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -168,6 +168,9 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     const brData = message.getFlag("betterrolls-swade2", "br_data");
     if (brData) {
         html.classList.add("brsw-chat-message");
+        if (SettingsUtils.allowDarkMode()) {
+            html.classList.add("brsw-allow-dark-mode");
+        }
 
         // This chat card is one of ours
         const brCard = new BrCommonCard(message);

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -167,6 +167,8 @@ Hooks.on("hideNPCNamesChatMessageUpdated", (message, html, options) => {
 Hooks.on("renderChatMessageHTML", (message, html, options) => {
     const brData = message.getFlag("betterrolls-swade2", "br_data");
     if (brData) {
+        html.classList.add("brsw-chat-message");
+
         // This chat card is one of ours
         const brCard = new BrCommonCard(message);
         activateCardListeners(brCard, html, message);

--- a/scripts/card-dialog.js
+++ b/scripts/card-dialog.js
@@ -4,7 +4,7 @@ export function setupDialog() {
   const dialogElement = document.createElement("dialog");
   dialogElement.setAttribute("id", "br-card-dialog");
   dialogElement.classList.add("brsw-dialog-bg");
-  document.body.insertAdjacentElement("beforeend", dialogElement);
+  document.querySelector("#interface").insertAdjacentElement("beforeend", dialogElement);
   game.brsw.dialog = new BrCardDialog();
 }
 

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -595,6 +595,8 @@ export function calculate_damage_results(rolls) {
             roll.result_text = game.i18n.localize("BRSW.Wounds") + " " + wounds;
             roll.result_icon = wounds.toString() + " " + '<i class="brsw-red-text fas fa-tint"></i>';
         }
+
+        roll.damageResultText = roll.result + (roll.ap ? `(${game.i18n.localize("BRSW.ApShort")} ${roll.ap})` : "");
     }
     if (result < 0) {
         result = 0;

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -335,7 +335,7 @@ function registerUserSettings() {
     SettingsUtils.registerBR2UserSetting(USER_SETTING_KEYS.allowDarkMode, {
         name: "BRSW.Settings.AllowDarkMode.Name",
         hint: "BRSW.Settings.AllowDarkMode.Hint",
-        default: true,
+        default: false,
         type: Boolean,
         onChange: () => {
             const messages = game.messages.contents.filter(m => m.getFlag("betterrolls-swade2", "br_data"));

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -331,6 +331,25 @@ function registerUserSettings() {
         default: true,
         type: Boolean,
     });
+
+    SettingsUtils.registerBR2UserSetting(USER_SETTING_KEYS.allowDarkMode, {
+        name: "BRSW.Settings.AllowDarkMode.Name",
+        hint: "BRSW.Settings.AllowDarkMode.Hint",
+        default: true,
+        type: Boolean,
+        onChange: () => {
+            const messages = game.messages.contents.filter(m => m.getFlag("betterrolls-swade2", "br_data"));
+            for (const message of messages) {
+                ui.chat.updateMessage(message);
+
+                //Loop over all the apps of this message and trigger their render
+                //This is needed to refresh things like popped out chat cards
+                for (const app of Object.values(message.apps)) {
+                    app.render();
+                }
+            }
+        },
+    });
 }
 
 function cacheSettings(savedSettings, settingsCache) {

--- a/scripts/settings_config.js
+++ b/scripts/settings_config.js
@@ -143,14 +143,21 @@ export class SettingsConfig extends HandlebarsApplicationMixin(ApplicationV2) {
         const canModifyWorld = game.user.hasPermission("SETTINGS_MODIFY");
         let requiresWorldReload = false;
         let requiresClientReload = false;
+        const changedCallbacks = [];
         for (let [k, v] of Object.entries(foundry.utils.expandObject(formData.object))) {
-            if (canModifyWorld && WORLD_SETTINGS[k] && WORLD_SETTINGS[k].value !== v) {
+            if (canModifyWorld && WORLD_SETTINGS[k] &&
+                (WORLD_SETTINGS[k].value !== undefined
+                    ? WORLD_SETTINGS[k].value !== v
+                    : WORLD_SETTINGS[k].default !== v)) {
                 WORLD_SETTINGS[k].value = v;
-                if (v === WORLD_SETTINGS[k].default) continue;
+                if (WORLD_SETTINGS[k].onChange) changedCallbacks.push(() => WORLD_SETTINGS[k].onChange(v));
                 requiresWorldReload = requiresWorldReload || !!WORLD_SETTINGS[k].requiresReload;
-            } else if (USER_SETTINGS[k] && USER_SETTINGS[k].value !== v) {
+            } else if (USER_SETTINGS[k] &&
+                (USER_SETTINGS[k].value !== undefined
+                    ? USER_SETTINGS[k].value !== v
+                    : USER_SETTINGS[k].default !== v)) {
                 USER_SETTINGS[k].value = v;
-                if (v === USER_SETTINGS[k].default) continue;
+                if (USER_SETTINGS[k].onChange) changedCallbacks.push(() => USER_SETTINGS[k].onChange(v));
                 requiresClientReload = requiresClientReload || !!USER_SETTINGS[k].requiresReload;
             }
         }
@@ -160,6 +167,8 @@ export class SettingsConfig extends HandlebarsApplicationMixin(ApplicationV2) {
         }
 
         await SettingsUtils.setUserSettings();
+
+        changedCallbacks.forEach(cb => cb());
 
         if (requiresWorldReload || requiresClientReload) {
             await this.constructor.reloadConfirm({ world: requiresWorldReload });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -840,6 +840,14 @@ export class SettingsUtils {
             ? USER_SETTINGS[key].value
             : USER_SETTINGS[key].default;
     }
+
+    static allowDarkMode() {
+        const userSettings = SettingsUtils.getModuleFlag(game.user, USER_FLAGS.userSettings);
+        const key = USER_SETTING_KEYS.allowDarkMode;
+        return userSettings[key] !== undefined
+            ? userSettings[key]
+            : USER_SETTINGS[key].default;
+    }
 }
 
 export class TelemetryUtils {

--- a/templates/damage_partial.hbs
+++ b/templates/damage_partial.hbs
@@ -53,7 +53,7 @@
                     {{#if this.dice}}
                         <span>{{#each this.dice.terms as |current_term|}}
                                 {{#each this.results}}
-                                    <span class="brsw-d{{current_term.faces}} brsw-dice-image">{{this.result}}</span>
+                                    <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
                                 {{/each}}
                             {{/each}}</span>
                     {{else}}

--- a/templates/damage_partial.hbs
+++ b/templates/damage_partial.hbs
@@ -5,7 +5,7 @@
                 {{../label}}:
             </span>
             <span class="brsw-damage-roll-damage">
-                <span class="{{roll.extra_class}}">{{roll.result}}{{#if roll.ap}} ({{localize "BRSW.ApShort"}} {{roll.ap}}){{/if}}</span>
+                <span class="{{roll.extra_class}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
                 <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
                         {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
                         {{#unless ../../bennie_available}}disabled{{/unless}}>
@@ -43,7 +43,7 @@
                 <div class="brsw-roll-detail-row {{this.extra_class}}">
                     <span>{{this.label}}</span>
                     <span>{{#each this.results}}
-                            <span class="brsw-d{{current_dice.faces}} brsw-dice-image">{{this}}</span>
+                            <span class="brsw-d{{current_dice.faces}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
                         {{/each}}</span>
                 </div>
             {{/each}}

--- a/templates/injury_card.hbs
+++ b/templates/injury_card.hbs
@@ -1,12 +1,12 @@
 {{>"modules/betterrolls-swade2/templates/common_card_header.hbs"}}
 <div>
   <div class="brsw-card-row">
-    <span class="brsw-d6 brsw-dice-image">{{first_roll.result}}</span>:
+    <span class="brsw-d6 brsw-dice-image" data-text="{{first_roll.result}}">{{first_roll.result}}</span>:
     <strong>{{first_location}}</strong>
   </div>
   {{#if second_location}}
   <div class="brsw-card-row">
-    <span class="brsw-d6 brsw-dice-image">{{second_roll.result}}</span>:
+    <span class="brsw-d6 brsw-dice-image" data-text="{{second_roll.result}}">{{second_roll.result}}</span>:
     <strong>{{second_location}}</strong>
   </div>
   {{/if}}

--- a/templates/trait_roll_partial.hbs
+++ b/templates/trait_roll_partial.hbs
@@ -64,7 +64,7 @@
                         <span>
                             {{#each this.dice.terms as |current_term|}}
                                 {{#each this.results}}
-                                    <span class="brsw-d{{current_term.faces}} brsw-dice-image">{{this.result}}</span>
+                                    <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
                                 {{/each}}
                             {{/each}}
                         </span>

--- a/templates/trait_roll_partial.hbs
+++ b/templates/trait_roll_partial.hbs
@@ -51,7 +51,7 @@
                 <span>{{this.label}}</span>
                 <span class="brsw-die-results">
                     {{#each this.unexploded}}
-                        <span class="brsw-d{{current_dice.sides}} brsw-dice-image">{{this}}</span>
+                        <span class="brsw-d{{current_dice.sides}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
                     {{/each}}
                 </span>
             </div>


### PR DESCRIPTION
## Summary by Sourcery

Introduce an optional dark-mode styling for Better Rolls chat cards and dialogs, controlled via a new user setting and applied through theme-aware CSS and template updates.

New Features:
- Add a user setting to allow dark mode for Better Rolls chat messages and cards, including automatic re-rendering of affected messages when toggled.

Bug Fixes:
- Ensure settings onChange callbacks are consistently invoked for both world and user settings when values change, even when reverting to defaults.

Enhancements:
- Refine button, dialog, note, damage result, and dice icon styling to use CSS variables so they can adapt between light and dark themes.
- Update chat card templates to provide data attributes for dice and damage results, enabling dark-mode-friendly overlays and parchment-style backgrounds.
- Attach the Better Rolls card dialog to the main interface container instead of the document body for better theming integration.