### PR TITLE
Target refactor and player pilot support

### DIFF
--- a/assets/cycle-player-pilot.svg
+++ b/assets/cycle-player-pilot.svg
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   style="height: 512px; width: 512px;"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="cycle.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.7539062"
+     inkscape:cx="255.71493"
+     inkscape:cy="256.00001"
+     inkscape:window-width="1920"
+     inkscape:window-height="1135"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="M0 0h512v512H0z"
+     fill="#000"
+     fill-opacity="1"
+     id="path1"
+     style="fill:rgb(98,199,178);fill-opacity:1" />
+  <g
+     class=""
+     transform="matrix(0.97341745,0,0,0.97341745,8.443147,8.530374)"
+     id="g2">
+    <path
+       d="m 252.314,19.957 c -72.036,0.363 -142.99,33.534 -189.18,95.97 -69.83,94.39 -59.125,223.32 19.85,304.993 L 45.746,471.252 196.966,448.639 174.35,297.42 131.213,355.728 c -44.08,-54.382 -47.723,-133.646 -4.16,-192.53 30.676,-41.466 77.863,-63.504 125.758,-63.753 16.344,-0.085 32.766,2.382 48.645,7.467 l -6.963,-46.55 C 270.635,55.502 246.585,55.336 223.476,59.365 164.244,66.687 109.482,99.283 75.319,150.58 110.969,84.69 179.093,44.662 251.362,42.836 c 1.673,-0.042 3.347,-0.063 5.023,-0.065 14.8,-0.01 29.748,1.596 44.597,4.905 L 349.59,40.408 C 318.45,26.502 285.27,19.788 252.316,19.955 Z m 212.93,22.055 -151.217,22.61 22.614,151.22 41.126,-55.588 c 42.204,54.29 45.092,132.048 2.187,190.043 -40.22,54.367 -108.82,75.32 -170.19,57.566 l 6.522,43.598 c 28.726,5.533 58.236,4.414 86.203,-3.07 37.448,-5.957 73.34,-22.05 103.16,-47.728 -49.196,54.65 -122.615,77.514 -191.744,64.34 l -55.8,8.344 c 99.03,43.7 218.402,14.77 285.51,-75.938 69.13,-93.445 59.34,-220.743 -17.483,-302.53 l 39.114,-52.866 z"
+       fill="#fff"
+       fill-opacity="1"
+       id="path2"
+       style="fill:#000000;fill-opacity:1" />
+  </g>
+</svg>

--- a/assets/magic-swirl-player-pilot.svg
+++ b/assets/magic-swirl-player-pilot.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   style="height: 512px; width: 512px;"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg2"
+   sodipodi:docname="magic-swirl.svg"
+   inkscape:version="1.3 (0e150ed6c4, 2023-07-21)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="namedview2"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="1.7539062"
+     inkscape:cx="255.71492"
+     inkscape:cy="256"
+     inkscape:window-width="1920"
+     inkscape:window-height="1135"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <path
+     d="M0 0h512v512H0z"
+     fill="#000"
+     fill-opacity="1"
+     id="path1"
+     style="fill:rgb(98,199,178);fill-opacity:1" />
+  <g
+     class=""
+     style="fill:#000000;fill-opacity:1"
+     transform="translate(0,0)"
+     id="g2">
+    <path
+       d="M247.79 18.734C137.967 17.596 19.874 96.94 19.73 244.53l21.403-51.395c-9.485 72.28-7.75 147.236 38.79 202.502L38.2 377.355c39.24 69.774 126.333 90.976 200.855 92.51C124.11 429.9 67.87 342.277 63.912 246.492c-6.722-211.78 260.658-217.694 340.78-75.77-3.417-19.492-8.623-38.426-15.618-56.11 77.406 89.155 59.293 214.875-21.29 253.036-24.25 3.95-48.93 12.06-60.954 19-58.548 33.802-6.27 126.536 53.225 92.188 9.44-5.45 23.404-17.303 36.494-31.352 64.36-59.52 98.1-118.24 93.108-188.94-6.52 29.1-19.175 57.904-35.623 84.683 63.158-146.822 7.956-263.89-144.838-301.354 12.097 5.835 23.503 13.63 33.873 23.36-57.415-23.752-131.123-22.62-186.884 3.505 28.066-26.2 64.776-43.73 102.2-49.642-3.52-.205-7.054-.325-10.597-.362zm-19.74 160.202l-19.843 100.566c-2.958 3.81-5.64 6.852-9.033 9.94l-25.688-49.096-22.705 11.93 31.37 60.945c4.48 11.474 10.02 20.68 15.162 28.524 28.063 42.803 64.547 35.252 95.303 9.555l87.28-48.452-12.71-22.498-66.136 36.94c-1.517-3.154-3.266-6.552-5.056-9.51l67.818-64.96-17.54-18.695-66.47 63.762c-2.356-2.318-4.238-4.527-6.765-6.54l45.084-78.085-22.733-13.127-45.864 78.297c-3.79-1.31-7.72-2.2-11.595-2.745l15.656-81.896-25.533-4.854z"
+       fill="#fff"
+       fill-opacity="1"
+       id="path2"
+       style="fill:#000000;fill-opacity:1" />
+  </g>
+</svg>

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -895,6 +895,10 @@
     border-bottom: 1px solid var(--brsw-color-gray-200);
 }
 
+.brsw-description {
+    margin: 0.5rem 0;
+}
+
 .brsw-card-note {
     margin: var(--brsw-spacing);
     padding: var(--brsw-spacing);

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -962,6 +962,10 @@
     overflow: visible;
 }
 
+.brsw-header-title:not(.brsw-collapse-button):hover {
+    text-shadow: none;
+}
+
 .brsw-header-img-wrapper {
     display: flex;
 }

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -48,7 +48,8 @@
     --brsw-transition-timing: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.themed.theme-dark .brsw-allow-dark-mode {
+.themed.theme-dark .brsw-allow-dark-mode,
+.theme-dark .brsw-allow-dark-mode#br-card-dialog {
     --brsw-chat-message-color: var(--color-light-2);
     --brsw-button-bg-color: var(--color-cool-5-50);
     --brsw-button-color: var(--color-light-3);
@@ -560,17 +561,16 @@
     flex-direction: column;
 }
 
-.themed.theme-dark .brsw-allow-dark-mode #br-card-dialog {
-    position: relative;
+.theme-dark .brsw-allow-dark-mode#br-card-dialog {
     background: none;
 }
 
-.themed.theme-dark .brsw-allow-dark-mode #br-card-dialog::before {
+.theme-dark .brsw-allow-dark-mode#br-card-dialog::before {
     content: "";
     position: absolute;
     inset: 0;
     background: url("/ui/parchment.jpg");
-    filter: brightness(15%);
+    filter: brightness(40%) contrast(250%);
     z-index: -1;
 }
 
@@ -605,21 +605,22 @@
 @media (max-width: 700px) {
     #br-card-dialog .brsw-action-section-groups {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        min-width: 100%;
+        max-width: 100%;
     }
 
     #br-card-dialog {
-        min-width: 96%;
+        max-width: 96%;
     }
 }
 
 @media (max-width: 500px) {
     #br-card-dialog .brsw-action-section-groups {
         grid-template-columns: 1fr;
+        max-width: 100%;
     }
 
     #br-card-dialog {
-        min-width: 96%;
+        max-width: 96%;
     }
 }
 

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -549,7 +549,7 @@
 
 #br-card-dialog {
     width: fit-content;
-    max-width: 100%;
+    max-width: 96%;
     margin-right: 2%;
     padding: 3px;
     background: url("/ui/parchment.jpg") repeat;
@@ -605,22 +605,16 @@
 @media (max-width: 700px) {
     #br-card-dialog .brsw-action-section-groups {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-        max-width: 100%;
     }
 
     #br-card-dialog {
-        max-width: 96%;
+        min-width: 96%;
     }
 }
 
 @media (max-width: 500px) {
     #br-card-dialog .brsw-action-section-groups {
         grid-template-columns: 1fr;
-        max-width: 100%;
-    }
-
-    #br-card-dialog {
-        max-width: 96%;
     }
 }
 

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -477,7 +477,7 @@
 
 #br-card-dialog {
     width: fit-content;
-    max-width: min-content;
+    max-width: 100%;
     margin-right: 2%;
     padding: 3px;
     background: url("/ui/parchment.jpg") repeat;
@@ -514,7 +514,28 @@
 
 #br-card-dialog .brsw-action-section-groups {
     display: grid;
-    grid-template-columns: repeat(3, minmax(max-content, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 700px) {
+    #br-card-dialog .brsw-action-section-groups {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        min-width: 100%;
+    }
+
+    #br-card-dialog {
+        min-width: 96%;
+    }
+}
+
+@media (max-width: 500px) {
+    #br-card-dialog .brsw-action-section-groups {
+        grid-template-columns: 1fr;
+    }
+
+    #br-card-dialog {
+        min-width: 96%;
+    }
 }
 
 #br-card-dialog .brsw-action-group {
@@ -524,6 +545,8 @@
     margin: 0.5em;
     border-color: oklch(0.373 0.034 259.733);
     border-radius: 8px;
+
+    min-width: 0;
 }
 
 #br-card-dialog .brsw-action-group .brsw-action-group-name {

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -1057,12 +1057,6 @@
     gap: 5px;
 }
 
-.brsw-damage-group {
-    display: grid;
-    grid-template-columns: subgrid;
-    grid-column: 1 / -1;
-}
-
 .brsw-damage-roll-row {
     display: grid;
     grid-template-columns: subgrid;
@@ -1070,6 +1064,10 @@
     gap: 5px;
     align-items: center;
     justify-items: end;
+}
+
+.brsw-damage-detail {
+    grid-column: 1 / -1;
 }
 
 .brsw-damage-roll-row > :nth-child(3n + 1) {
@@ -1088,9 +1086,10 @@
 .brsw-damage-roll-damage > span {
     min-width: 2em;
     min-height: 2em;
+    min-height: stretch;
+    margin-right: 0.25em;
     text-align: center;
     align-content: center;
-    min-height: stretch;
     background-size: 2em 2em;
     background-repeat: no-repeat;
     background-position: center;

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -22,6 +22,9 @@
 
     --brsw-color-selected-tag-text: #ffe2dc;
 
+    --brsw-chat-message-color: black;
+
+    --brsw-button-color: black;
     --brsw-button-bg-color: white;
 
     --brsw-card-note-warning-color: #FF6467;
@@ -1047,9 +1050,22 @@
 
 /* Damage partial */
 
+.brsw-damage-rows {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) max-content max-content;
+    gap: 5px;
+}
+
+.brsw-damage-group {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+}
+
 .brsw-damage-roll-row {
     display: grid;
-    grid-template-columns: auto 105px 60px;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
     gap: 5px;
     align-items: center;
     justify-items: end;

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -68,14 +68,12 @@
     font-weight: var(--brsw-font-weight-bold);
 }
 
-.brsw-common-modifiers {
-    display: flex;
-}
-
 /* Styles for the card body */
 
 .brsw-common-modifiers {
+    display: flex;
     margin-bottom: 5px;
+    align-items: center;
 }
 
 .brsw-selectable {

--- a/scripts/BrCommonCard.js
+++ b/scripts/BrCommonCard.js
@@ -9,7 +9,7 @@ import { are_bennies_available, traitToDieString } from "./cards_common.js";
 import { get_actions, process_action } from "./global_actions.js";
 import { calc_pp_cost } from "./item_card.js";
 import { TraitRoll } from "./rolls.js";
-import { broofa, getAuthor, getWhisperData, SettingsUtils, Utils } from "./utils.js";
+import { broofa, getAuthor, getUserTargets, getWhisperData, SettingsUtils, Utils } from "./utils.js";
 
 /**
  * Stores a flag with the render data, deletes data can't be stored
@@ -342,8 +342,8 @@ export class BrCommonCard {
 
     recover_targets_from_user() {
         this.target_ids = [];
-        for (const target of game.user.targets) {
-            this.target_ids.push(target.document.uuid);
+        for (const target of getUserTargets()) {
+            this.target_ids.push(target.uuid);
         }
     }
 
@@ -396,8 +396,9 @@ export class BrCommonCard {
 
     populateWorldActions() {
         const item = this.item || this.skill || { type: "attribute", name: this.attribute };
+        const userTargets = getUserTargets();
 
-        for (const global_action of get_actions(item, this.actor)) {
+        for (const global_action of get_actions(item, this.actor, userTargets)) {
             const name = game.i18n.localize(global_action.button_name);
             const section_name = (global_action.section ? global_action.section : "none").toLowerCase();
             const group_name = global_action.group || "BRSW.NoGroup";
@@ -429,7 +430,7 @@ export class BrCommonCard {
                 if (global_action.defaultChecked === "on") {
                     new_action.selected = true;
                 } else {
-                    new_action.selected = process_action(global_action, item, this.actor, true);
+                    new_action.selected = process_action(global_action, item, this.actor, userTargets, true);
                 }
             }
 

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -179,13 +179,42 @@ export function decorateCardHTML(brCard, html, message) {
     const textMeasureContext = document.createElement("canvas").getContext("2d");
 
     const headerTitle = html.querySelector(".brsw-header-title");
-    if (headerTitle) {
-        textMeasureContext.font = `18px Signika`;
-        const width = textMeasureContext.measureText(headerTitle.textContent).width;
-        const maxWidth = 168;
-        const defaultFontSize = 18;
-        const fontSize = width > 0 ? Math.min(defaultFontSize, defaultFontSize * (maxWidth / width)) : defaultFontSize;
-        headerTitle.style.setProperty("font-size", `${fontSize}px`);
+    const headerRow = headerTitle?.closest(".brsw-card-header-row");
+    if (headerTitle && headerRow) {
+        const tryFitHeaderTitle = () => {
+            //Measure the size of the everything else in the row
+            const headerWrapper = headerRow.querySelector(".brsw-header-title-wrapper");
+            const childRects = Array.from(headerRow.children)
+                .filter((child) => child !== headerWrapper)
+                .map((child) => child.getBoundingClientRect())
+                .filter((rect) => rect.width > 0 && rect.height > 0);
+
+            const reservedWidth = childRects.reduce((total, rect) => total + rect.width, 0);
+            const availableWidth = Math.max(0, headerRow.clientWidth - reservedWidth) * 0.9; //0.9 to give it a bit of room
+            if (availableWidth <= 0) return false; // not laid out yet, keep waiting
+
+            const referenceFontSize = 18;
+            textMeasureContext.font = `${referenceFontSize}px Signika`;
+            const textWidth = textMeasureContext.measureText(headerTitle.textContent).width;
+            const minFontSize = 10;
+            const headerFontSize = parseFloat(getComputedStyle(headerTitle).getPropertyValue("--header-font-size"));
+            const maxFontSize = Number.isFinite(headerFontSize) ? headerFontSize : referenceFontSize;
+            const fontSize = textWidth > 0
+                ? Math.min(maxFontSize, Math.max(minFontSize, referenceFontSize * (availableWidth / textWidth)))
+                : referenceFontSize;
+            headerTitle.style.setProperty("font-size", `${fontSize}px`);
+            return true;
+        };
+
+        if (!tryFitHeaderTitle()) {
+            //The DOM hasn't been finalized yet so we'll need to wait for a callback
+            const resizeObserver = new ResizeObserver(() => {
+                if (tryFitHeaderTitle()) resizeObserver.disconnect();
+            });
+            resizeObserver.observe(headerRow);
+            // Safety so it doesn't live forever
+            setTimeout(() => resizeObserver.disconnect(), 10000);
+        }
     }
 
     fitDamageTargetText(html, textMeasureContext);

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -39,7 +39,7 @@ import {
     activate_skill_listeners,
     exposeSkillCardAPI,
 } from "./skill_card.js";
-import { SettingsUtils, TelemetryUtils, Utils, cacheSkillData, measureDistance } from "./utils.js";
+import { SettingsUtils, TelemetryUtils, Utils, cacheSkillData, getUserTargets, measureDistance } from "./utils.js";
 import { activate_vehicle_listeners } from "./vehicle_card.js";
 
 // Init Hook
@@ -72,6 +72,8 @@ Hooks.on(`ready`, async () => {
     exposeGlobalActionsAPI();
     exposeCardClass();
     exposeIncapacitationCardAPI();
+    Utils.exposeAPI("activateCardListeners", activateCardListeners);
+    Utils.exposeAPI("decorateCardHTML", decorateCardHTML);
     setupChatButton();
     await cacheSkillData();
 
@@ -119,7 +121,12 @@ Hooks.on(`ready`, async () => {
 
 // Hooks on render
 
-function activateCardListeners(brCard, html, message) {
+/**
+ * @param {BrCommonCard} brCard
+ * @param {HTMLElement} html Root element containing the rendered card markup
+ * @param {ChatMessage} message The parent chat message
+ */
+export function activateCardListeners(brCard, html, message) {
     activateCommonListeners(brCard, html);
     if (brCard.type === BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD) {
         activateAttributeCardListeners(brCard, html);
@@ -139,7 +146,61 @@ function activateCardListeners(brCard, html, message) {
     }
 }
 
-Hooks.on("createChatMessage", (message, options, userId) => {
+/**
+ * This function applies the final touches to the display of the chat card
+ * This is exposed to the API to allow other modules to apply the same behaviour to their messages
+ *
+ * @param {BrCommonCard} brCard
+ * @param {HTMLElement} html
+ * @param {ChatMessage} message
+ */
+export function decorateCardHTML(brCard, html, message) {
+    if (!message.isOwner) {
+        html.querySelectorAll(".brsw-form").forEach((e) => e.classList.add("brsw-collapsed"));
+        html.querySelector(".brsw-pp-toggle")?.remove();
+        html.querySelector(".brsw-pp-manual")?.remove();
+        html.querySelector(".brsw-ammo-toggle")?.remove();
+        html.querySelector(".brsw-ammo-manual")?.remove();
+    }
+
+    if (!game.user.isGM) {
+        html.querySelectorAll(".brsw-master-only").forEach((e) => e.remove());
+    }
+
+    if (!message.isOwner && !game.user.isTrusted) {
+        html.querySelectorAll(".brsw-owner-trusted-only").forEach((e) => e.remove());
+    }
+
+    const damageSection = html.querySelector(".brsw-damage-section");
+    if (damageSection) {
+        damageSection.hidden = !brCard.damage;
+    }
+
+    const textMeasureContext = document.createElement("canvas").getContext("2d");
+
+    const headerTitle = html.querySelector(".brsw-header-title");
+    if (headerTitle) {
+        textMeasureContext.font = `18px Signika`;
+        const width = textMeasureContext.measureText(headerTitle.textContent).width;
+        const maxWidth = 168;
+        const defaultFontSize = 18;
+        const fontSize = width > 0 ? Math.min(defaultFontSize, defaultFontSize * (maxWidth / width)) : defaultFontSize;
+        headerTitle.style.setProperty("font-size", `${fontSize}px`);
+    }
+
+    fitDamageTargetText(html, textMeasureContext);
+
+    if (game.user.isGM) {
+        const applyDamageTitle = game.i18n.localize("BRSW.ApplyDamage");
+        html.querySelectorAll(".brsw-apply-damage").forEach((applyButton) => {
+            const targetId = applyButton.dataset.target;
+            applyButton.disabled = !targetId || Number(applyButton.dataset.damage) === 0;
+            applyButton.title = targetId ? applyDamageTitle : "";
+        });
+    }
+}
+
+Hooks.on("createChatMessage", (message, _options, _userId) => {
     const brData = message.getFlag("betterrolls-swade2", "br_data");
     if (brData) {
         if (brData.showPopout) {
@@ -154,74 +215,13 @@ Hooks.on("createChatMessage", (message, options, userId) => {
     }
 });
 
-Hooks.on("hideNPCNamesChatMessageUpdated", (message, html, options) => {
-    const brData = message.getFlag("betterrolls-swade2", "br_data");
-    if (brData) {
-        //We just updated the chat card to replace a name
-        //Re-fit our target name so it's consistent with the replaced name
-        const textMeasureContext = document.createElement("canvas").getContext("2d");
-        fitDamageTargetText(html, textMeasureContext);
-    }
-});
-
-Hooks.on("renderChatMessageHTML", (message, html, options) => {
+Hooks.on("renderChatMessageHTML", (message, html, _options) => {
     const brData = message.getFlag("betterrolls-swade2", "br_data");
     if (brData) {
         // This chat card is one of ours
         const brCard = new BrCommonCard(message);
         activateCardListeners(brCard, html, message);
-
-        // Hide forms to non-master, non owner
-        if (!message.isOwner) {
-            html.querySelectorAll(".brsw-form").forEach((e) => e.classList.add("brsw-collapsed"));
-        }
-
-        if (!message.isOwner) {
-            //Remove the PP and ammo management buttons for non-owners
-            html.querySelector(".brsw-pp-toggle")?.remove();
-            html.querySelector(".brsw-pp-manual")?.remove();
-            html.querySelector(".brsw-ammo-toggle")?.remove();
-            html.querySelector(".brsw-ammo-manual")?.remove();
-        }
-
-        // Hide master only sections
-        if (!game.user.isGM) {
-            html.querySelectorAll(".brsw-master-only").forEach((e) => e.remove());
-        }
-
-        // Hide save macro button from non-owner, non-trusted players
-        if (!message.isOwner && !game.user.isTrusted) {
-            html.querySelectorAll(".brsw-owner-trusted-only").forEach((e) => e.remove());
-        }
-
-        const damageSection = html.querySelector(".brsw-damage-section");
-        if (damageSection) {
-            //If we have damage, show the damage section
-            damageSection.hidden = !brCard.damage;
-        }
-
-        const textMeasureContext = document.createElement("canvas").getContext("2d");
-
-        const headerTitle = html.querySelector(".brsw-header-title");
-        if (headerTitle) {
-            textMeasureContext.font = `18px Signika`;
-            const width = textMeasureContext.measureText(headerTitle.textContent).width;
-            const maxWidth = 168;
-            const defaultFontSize = 18;
-            const fontSize = width > 0 ? Math.min(defaultFontSize, defaultFontSize * (maxWidth / width)) : defaultFontSize;
-            headerTitle.style.setProperty("font-size", `${fontSize}px`);
-        }
-
-        fitDamageTargetText(html, textMeasureContext);
-
-        if (game.user.isGM) {
-            const applyDamageTitle = game.i18n.localize("BRSW.ApplyDamage");
-            html.querySelectorAll(".brsw-apply-damage").forEach((applyButton) => {
-                const targetId = applyButton.dataset.target;
-                applyButton.disabled = !targetId || Number(applyButton.dataset.damage) === 0;
-                applyButton.title = targetId ? applyDamageTitle : "";
-            });
-        }
+        decorateCardHTML(brCard, html, message);
 
         // Scroll the chat to the bottom if this is the last message
         if (game.messages.contents[game.messages.contents.length - 1] === message) {
@@ -237,6 +237,16 @@ Hooks.on("renderChatMessageHTML", (message, html, options) => {
     }
 });
 
+Hooks.on("hideNPCNamesChatMessageUpdated", (message, html, options) => {
+    const brData = message.getFlag("betterrolls-swade2", "br_data");
+    if (brData) {
+        //We just updated the chat card to replace a name
+        //Re-fit our target name so it's consistent with the replaced name
+        const textMeasureContext = document.createElement("canvas").getContext("2d");
+        fitDamageTargetText(html, textMeasureContext);
+    }
+});
+
 // Addon by JuanV, make attack target possible by drag and drop
 Hooks.on("dropCanvasData", (canvas, item) => {
     if (item.type === "Item" || item.type === "target_click") {
@@ -248,7 +258,7 @@ Hooks.on("dropCanvasData", (canvas, item) => {
             height: square_size,
             width: square_size,
         });
-        if (game.user.targets.size) {
+        if (getUserTargets().length) {
             if (item.type === "Item") {
                 Item.implementation.fromDropData(item).then((item) => {
                     let token_id;

--- a/scripts/card-dialog.js
+++ b/scripts/card-dialog.js
@@ -1,10 +1,17 @@
-// A dialog to manage br cards
+// A dialog to select card actions
+
+import { SettingsUtils } from "./utils.js";
 
 export function setupDialog() {
   const dialogElement = document.createElement("dialog");
   dialogElement.setAttribute("id", "br-card-dialog");
   dialogElement.classList.add("brsw-dialog-bg");
-  document.querySelector("#interface").insertAdjacentElement("beforeend", dialogElement);
+
+  if (SettingsUtils.allowDarkMode()) {
+    dialogElement.classList.add("brsw-allow-dark-mode");
+  }
+
+  document.body.insertAdjacentElement("beforeend", dialogElement);
   game.brsw.dialog = new BrCardDialog();
 }
 
@@ -13,7 +20,7 @@ class BrCardDialog {
     this.BrCard = null;
   }
 
-  get dialog_element() {
+  get dialogElement() {
     return document.getElementById("br-card-dialog");
   }
 
@@ -22,7 +29,7 @@ class BrCardDialog {
     this.render().catch((err) => {
       console.error("Error rendering dialog", err);
     });
-    this.dialog_element.showModal();
+    this.dialogElement.showModal();
   }
 
   async render() {
@@ -41,7 +48,7 @@ class BrCardDialog {
         return a.name > b.name ? 1 : -1;
       });
     }
-    this.dialog_element.innerHTML = await foundry.applications.handlebars.renderTemplate(
+    this.dialogElement.innerHTML = await foundry.applications.handlebars.renderTemplate(
       "modules/betterrolls-swade2/templates/card_dialog.hbs",
       { BrCard: this.BrCard, sections },
     );
@@ -82,8 +89,8 @@ class BrCardDialog {
 
   close_card() {
     this.BrCard = null;
-    this.dialog_element.innerHTML = "";
-    this.dialog_element.close();
+    this.dialogElement.innerHTML = "";
+    this.dialogElement.close();
   }
 
   async save_actions() {

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -31,6 +31,7 @@ import {
     addEventListenerAll,
     getSelectedToken,
     getTargetedToken,
+    getUserTargets,
     set_or_update_condition,
     simple_form,
     spendMastersBenny,
@@ -1290,14 +1291,9 @@ export function process_common_actions(action, extra_data, macros, actor) {
         extra_data.rof = action.dice;
     }
     if (action.tnOverride) {
-        if (
-            isNaN(action.tnOverride) &&
-            action.tnOverride.toLowerCase() === "parry" &&
-            game.user.targets
-        ) {
-            extra_data.tn = parseInt(
-                game.user.targets.first().actor.system.stats.parry.value,
-            );
+        const userTargets = getUserTargets();
+        if (isNaN(action.tnOverride) && action.tnOverride.toLowerCase() === "parry" && userTargets[0]) {
+            extra_data.tn = parseInt(userTargets[0].actor.system.stats.parry.value);
         } else {
             extra_data.tn = parseInt(action.tnOverride);
         }

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -329,7 +329,7 @@ export function fitDamageTargetText(html, textMeasureContext) {
 
     const tryFitDamageTargetText = () => {
         const damageTargetFontSize = parseFloat(getComputedStyle(damageRows).getPropertyValue("--damage-target-font-size"));
-        const availableWidth = Number.parseFloat(getComputedStyle(damageRows).gridTemplateColumns.split(" ")[0]) || 0;
+        const availableWidth = (Number.parseFloat(getComputedStyle(damageRows).gridTemplateColumns.split(" ")[0]) || 0);
         if (availableWidth <= 0) return false; // not laid out yet, keep waiting
 
         const damageRollRows = html.querySelectorAll(".brsw-damage-roll-row");
@@ -361,12 +361,12 @@ export function fitDamageTargetText(html, textMeasureContext) {
                     }
                 }
 
-                if (lines <= maxLines) {
-                    //We've found a size that fits our max lines, so we can't be smaller than this
-                    minSize = fontSize;
-                } else {
+                if (lines > maxLines || (words.length === 1 && width > availableWidth)) {
                     //This doesn't fit which means we can't be larger than this
                     maxSize = fontSize;
+                } else {
+                    //We've found a size that fits our max lines, so we can't be smaller than this
+                    minSize = fontSize;
                 }
             }
 

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -27,7 +27,7 @@ export async function createDamageCard(
     damage_text,
     heavyDamage,
 ) {
-    const token = canvas.tokens.get(token_id);
+    const token = canvas?.tokens.get(token_id);
     const { actor } = token;
     const user = get_owner(actor);
 

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -321,44 +321,67 @@ async function rollSoak(brCard, useBenny) {
 }
 
 export function fitDamageTargetText(html, textMeasureContext) {
-    const maxWidth = 100;
     const maxLines = 2;
-    const minFontSize = 8;
-    const maxFontSize = 14;
+    const referenceFontSize = 14;
 
-    html.querySelectorAll(".brsw-damage-roll-target").forEach((rollTarget) => {
-        const words = rollTarget.textContent.trim().split(/\s+/);
+    const damageRows = html.querySelector(".brsw-damage-rows");
+    if (!damageRows?.children.length) return;
 
-        let minSize = minFontSize;
-        let maxSize = maxFontSize;
+    const tryFitDamageTargetText = () => {
+        const damageTargetFontSize = parseFloat(getComputedStyle(damageRows).getPropertyValue("--damage-target-font-size"));
+        const availableWidth = Number.parseFloat(getComputedStyle(damageRows).gridTemplateColumns.split(" ")[0]) || 0;
+        if (availableWidth <= 0) return false; // not laid out yet, keep waiting
 
-        //Run a binary search to find the minimum font size that will fit our text
-        while (minSize + 1 < maxSize) {
-            const fontSize = (minSize + maxSize) / 2;
-            textMeasureContext.font = `${fontSize}px Signika`;
+        const damageRollRows = html.querySelectorAll(".brsw-damage-roll-row");
+        for (const damageRollRow of damageRollRows) {
+            const damageRollTarget = damageRollRow.querySelector(".brsw-damage-roll-target");
 
-            let width = 0;
-            let lines = 1;
+            const minFontSize = 8;
+            const maxFontSize = Number.isFinite(damageTargetFontSize) ? damageTargetFontSize : referenceFontSize;
 
-            for (const word of words) {
-                const wordWidth = textMeasureContext.measureText(`${word} `).width;
-                if (width + wordWidth > maxWidth) {
-                    lines++;
-                    width = wordWidth;
+            let minSize = minFontSize;
+            let maxSize = maxFontSize;
+
+            //Run a binary search to find the minimum font size that will fit our text
+            while (minSize + 1 < maxSize) {
+                const fontSize = (minSize + maxSize) / 2;
+                textMeasureContext.font = `${fontSize}px Signika`;
+
+                let width = 0;
+                let lines = 1;
+
+                const words = damageRollTarget.textContent.trim().split(/\s+/);
+                for (const word of words) {
+                    const wordWidth = textMeasureContext.measureText(`${word} `).width;
+                    if (width + wordWidth > availableWidth) {
+                        lines++;
+                        width = wordWidth;
+                    } else {
+                        width += wordWidth;
+                    }
+                }
+
+                if (lines <= maxLines) {
+                    //We've found a size that fits our max lines, so we can't be smaller than this
+                    minSize = fontSize;
                 } else {
-                    width += wordWidth;
+                    //This doesn't fit which means we can't be larger than this
+                    maxSize = fontSize;
                 }
             }
 
-            if (lines <= maxLines) {
-                //We've found a size that fits our max lines, so we can't be smaller than this
-                minSize = fontSize;
-            } else {
-                //This doesn't fit which means we can't be larger than this
-                maxSize = fontSize;
-            }
+            damageRollTarget.style.setProperty("font-size", `${minSize}px`);
         }
+        return true;
+    };
 
-        rollTarget.style.fontSize = `${minSize}px`;
-    });
+    if (!tryFitDamageTargetText()) {
+        //The DOM hasn't been finalized yet so we'll need to wait for a callback
+        const resizeObserver = new ResizeObserver(() => {
+            if (tryFitDamageTargetText()) resizeObserver.disconnect();
+        });
+        resizeObserver.observe(damageRows);
+        // Safety so it doesn't live forever
+        setTimeout(() => resizeObserver.disconnect(), 10000);
+    }
 }

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -27,7 +27,7 @@ export async function createDamageCard(
     damage_text,
     heavyDamage,
 ) {
-    const token = canvas?.tokens.get(token_id);
+    const token = canvas.tokens.get(token_id);
     const { actor } = token;
     const user = get_owner(actor);
 

--- a/scripts/global_actions.js
+++ b/scripts/global_actions.js
@@ -58,8 +58,8 @@ function addActions(actions) {
 /**
  * Process the not selector
  */
-function process_not_selector(action, item, actor) {
-    return !process_action(action.not_selector[0], item, actor);
+function process_not_selector(action, item, actor, userTargets) {
+    return !process_action(action.not_selector[0], item, actor, userTargets);
 }
 
 /**
@@ -77,10 +77,10 @@ export function exposeGlobalActionsAPI() {
  * @param actor
  * @return {boolean}
  */
-function process_and_selector(action, item, actor) {
+function process_and_selector(action, item, actor, userTargets) {
     let selected = true;
     for (const selection_option of action.and_selector) {
-        if (!process_action(selection_option, item, actor)) {
+        if (!process_action(selection_option, item, actor, userTargets)) {
             selected = false;
             break;
         }
@@ -95,10 +95,10 @@ function process_and_selector(action, item, actor) {
  * @param actor
  * @return {boolean}
  */
-function process_or_selector(action, item, actor) {
+function process_or_selector(action, item, actor, userTargets) {
     let selected = false;
     for (const selection_option of action.or_selector) {
-        if (process_action(selection_option, item, actor)) {
+        if (process_action(selection_option, item, actor, userTargets)) {
             selected = true;
             break;
         }
@@ -113,7 +113,7 @@ function process_or_selector(action, item, actor) {
  * @param actor
  * @return {boolean}
  */
-export function process_action(action, item, actor, useDefaultChecked) {
+export function process_action(action, item, actor, userTargets, useDefaultChecked) {
     let selected = false;
     const selectorObject = useDefaultChecked ? action.defaultChecked : action;
     if (selectorObject.hasOwnProperty("selector_type")) {
@@ -122,13 +122,14 @@ export function process_action(action, item, actor, useDefaultChecked) {
             selectorObject.selector_value,
             item,
             actor,
+            userTargets,
         );
     } else if (selectorObject.hasOwnProperty("and_selector")) {
-        selected = process_and_selector(selectorObject, item, actor);
+        selected = process_and_selector(selectorObject, item, actor, userTargets);
     } else if (selectorObject.hasOwnProperty("or_selector")) {
-        selected = process_or_selector(selectorObject, item, actor);
+        selected = process_or_selector(selectorObject, item, actor, userTargets);
     } else if (selectorObject.hasOwnProperty("not_selector")) {
-        selected = process_not_selector(selectorObject, item, actor);
+        selected = process_not_selector(selectorObject, item, actor, userTargets);
     }
     return selected;
 }
@@ -138,7 +139,7 @@ export function process_action(action, item, actor, useDefaultChecked) {
  * @param {Item} item
  * @param {SwadeActor} actor
  */
-export function get_actions(item, actor) {
+export function get_actions(item, actor, userTargets) {
     const availableActions = [];
 
     let disabledActions = SettingsUtils.getSetting(BRSW2_CONFIG.SETTING_KEYS.disabledSystemActions);
@@ -147,7 +148,7 @@ export function get_actions(item, actor) {
     }
 
     for (const action of game.brsw.GLOBAL_ACTIONS) {
-        if (!disabledActions.includes(action.id) && process_action(action, item, actor)) {
+        if (!disabledActions.includes(action.id) && process_action(action, item, actor, userTargets)) {
             availableActions.push(action);
         }
     }
@@ -166,7 +167,7 @@ export function get_actions(item, actor) {
  * @param actor actor been checked
  */
 // eslint-disable-next-line complexity
-function check_selector(type, value, item, actor) {
+function check_selector(type, value, item, actor, userTargets) {
     let selected = false;
     if (type === "skill") {
         if (item.type === "attribute") {
@@ -334,7 +335,7 @@ function check_selector(type, value, item, actor) {
         }
     } else if (type.indexOf("target_additional_stat_") === 0) {
         const additional_stat = type.slice(23);
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             if (targeted_token?.actor?.system?.additionalStats.hasOwnProperty(additional_stat)) {
                 if (Utils.check_equality_with_operators(targeted_token.actor.system.additionalStats[additional_stat].value, value)) {
                     selected = true;
@@ -346,7 +347,7 @@ function check_selector(type, value, item, actor) {
         selected = actor.hasJoker;
     } else if (type === "target_has_edge") {
         const edge_name = game.i18n.localize(value);
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             const edge = targeted_token.actor?.items.find((item) => {
                 return (
                     item.type === "edge" &&
@@ -360,7 +361,7 @@ function check_selector(type, value, item, actor) {
         selected = hasMastery == value;
     } else if (type === "target_has_hindrance") {
         const hindrance_name = game.i18n.localize(value);
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             const hindrance = targeted_token.actor?.items.find((item) => {
                 return (
                     item.type === "hindrance" &&
@@ -372,7 +373,7 @@ function check_selector(type, value, item, actor) {
     } else if (type === "target_has_major_hindrance") {
         const hindrance_name = game.i18n.localize(value);
         // noinspection AnonymousFunctionJS
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             const hindrance = targeted_token.actor?.items.find((item) => {
                 return (
                     item.type === "hindrance" &&
@@ -384,7 +385,7 @@ function check_selector(type, value, item, actor) {
         }
     } else if (type === "target_has_ability") {
         const ability_name = game.i18n.localize(value);
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             const ability = targeted_token.actor?.items.find((item) => {
                 return (
                     item.type === "ability" &&
@@ -396,7 +397,7 @@ function check_selector(type, value, item, actor) {
     } else if (type === "target_has_effect") {
         selected = false;
         const abilityName = game.i18n.localize(value);
-        for (const targeted_token of game.user.targets) {
+        for (const targeted_token of userTargets) {
             const effect = targeted_token.actor?.appliedEffects.find(
                 (ef) => ef.name.toLowerCase().includes(abilityName.toLowerCase()), // jshint ignore:line
             );
@@ -408,11 +409,11 @@ function check_selector(type, value, item, actor) {
         const gm_actions = get_enabled_gm_actions();
         selected = !!gm_actions.find((a) => a.id == value);
     } else if (type === "faction") {
-        const token = actor.getActiveTokens()[0];
-        const targetToken = game.user.targets.first();
-        if (token && targetToken && token !== targetToken) {
-            const actor_disposition = token.document.disposition;
-            const target_disposition = game.user.targets.first().document.disposition;
+        const token = Utils.toTokenDoc(actor.getActiveTokens()[0]) ?? actor.prototypeToken;
+        const targetToken = userTargets[0];
+        if (token && targetToken && token.actor?.id !== targetToken.actor?.id) {
+            const actor_disposition = token.disposition;
+            const target_disposition = targetToken.disposition;
             if (value === "same") {
                 selected = actor_disposition === target_disposition;
             } else {
@@ -436,7 +437,7 @@ function check_selector(type, value, item, actor) {
     } else if (type === "item_value") {
         selected = check_document_value(item, value);
     } else if (type === "target_value") {
-        const targeted_token = game.user.targets.first();
+        const targeted_token = userTargets[0];
         if (targeted_token) {
             selected = check_document_value(targeted_token.actor, value);
         }
@@ -451,8 +452,8 @@ function check_selector(type, value, item, actor) {
             selected = !selected;
         }
     } else if (type === "range_less_than") {
-        const token = actor.getActiveTokens()[0];
-        const targetToken = game.user.targets.first();
+        const token = Utils.toTokenDoc(actor.getActiveTokens()[0]) ?? actor.prototypeToken;
+        const targetToken = userTargets[0];
         if (token && targetToken) {
             const distance = measureDistance(token, targetToken);
             selected = parseInt(value) >= distance;

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -1106,12 +1106,7 @@ async function roll_dmg_target(
     await roll.evaluate();
 
     // Heavy armor
-    if (
-        target &&
-        !item.system.isHeavyWeapon &&
-        !damageFormulas.heavy_weapon &&
-        has_heavy_armor(target, damageFormulas.location)
-    ) {
+    if (target && !item.system.isHeavyWeapon && !damageFormulas.heavy_weapon && hasHeavyArmor(target.actor, damageFormulas.location)) {
         const no_damage_mod = new DamageModifier(
             game.i18n.localize("BRSW.HeavyArmor"),
             -999999,
@@ -1770,9 +1765,9 @@ function get_template_from_item(item) {
  * Returns true if the target wears a Heavy Armor
  * @param {PlaceableObject} target
  */
-function has_heavy_armor(target, location = "torso") {
+function hasHeavyArmor(target, location = "torso") {
     // Equipped is equipStatus 3
-    return target.document.actor.itemTypes.armor.some(
+    return target.itemTypes.armor.some(
         (item) =>
             item.system.isHeavyArmor &&
             item.system.locations[location] &&

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -33,6 +33,7 @@ import {
     broofa,
     getAuthor,
     getTargetedToken,
+    getUserTargets,
     makeExplodable,
     set_or_update_condition,
     simple_form,
@@ -1548,8 +1549,8 @@ async function get_dmg_targets(token_id, brCard) {
             return [token];
         }
     }
-    let targets = await game.user.targets;
-    if (targets.size > 0) {
+    let targets = getUserTargets();
+    if (targets.length > 0) {
         targets = Array.from(targets).filter((token) => token.actor);
     } else if (brCard.targets.length > 0) {
         targets = brCard.targets;
@@ -1797,7 +1798,7 @@ async function execute_macro(action, brCard) {
         targetActor = brCard.actor;
         targetToken = brCard.token;
     } else if (action.macroActor === "target") {
-        targetToken = game.user.targets.first() || brCard.token;
+        targetToken = getUserTargets()[0] || brCard.token;
         targetActor = targetToken.actor;
     } else {
         targetToken = game.canvas.tokens.controlled.length < 1 ? brCard.token : game.canvas.tokens.controlled[0];

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -594,7 +594,7 @@ export function activateItemCardListeners(brCard, html) {
  * @param {integer} trait_mod
  */
 async function roll_resist(trait, brCard, trait_mod) {
-    if (canvas.tokens.controlled.length === 0) {
+    if (!canvas.tokens?.controlled.length) {
         ui.notifications.warn(game.i18n.localize("BRSW.NoTokenSelectedError"));
         return;
     }
@@ -1539,7 +1539,7 @@ function get_global_modifiers(
  */
 async function get_dmg_targets(token_id, brCard) {
     if (token_id) {
-        const token = canvas.tokens.get(token_id);
+        const token = canvas.tokens?.get(token_id);
         if (token) {
             return [token];
         }
@@ -1796,8 +1796,8 @@ async function execute_macro(action, brCard) {
         targetToken = getUserTargets()[0] || brCard.token;
         targetActor = targetToken.actor;
     } else {
-        targetToken = game.canvas.tokens.controlled.length < 1 ? brCard.token : game.canvas.tokens.controlled[0];
-        targetActor = game.canvas.tokens.controlled.length < 1 ? brCard.actor : game.canvas.tokens.controlled[0].actor;
+        targetToken = game.canvas.tokens?.controlled.length < 1 ? brCard.token : game.canvas.tokens?.controlled[0];
+        targetActor = game.canvas.tokens?.controlled.length < 1 ? brCard.actor : game.canvas.tokens?.controlled[0].actor;
     }
     await macro.execute({
         actor: targetActor,

--- a/scripts/manual_mods_popup.js
+++ b/scripts/manual_mods_popup.js
@@ -70,11 +70,13 @@ export class ManualModifiersPopup extends HandlebarsApplicationMixin(Application
         this.element.style.right = `${right}px`;
 
         //Close the popup if we click outside of it
-        document.addEventListener("click", this.clickListener = (event) => {
-            if (!event.composedPath().includes(this.element)) {
-                this.close();
-            }
-        }, { passive: true });
+        if (!this.clickListener) {
+            document.addEventListener("click", this.clickListener = (event) => {
+                if (!event.composedPath().includes(this.element)) {
+                    this.close();
+                }
+            }, { passive: true });
+        }
 
         const modButtons = this.element.querySelectorAll(".brsw-selectable");
         for (const modButton of modButtons) {

--- a/scripts/manual_mods_popup.js
+++ b/scripts/manual_mods_popup.js
@@ -7,106 +7,118 @@ const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
  * Popup for selecting additional modifiers for a card
  */
 export class ManualModifiersPopup extends HandlebarsApplicationMixin(ApplicationV2) {
-  static DEFAULT_OPTIONS = {
-    id: "manual-modifiers-popup",
-    tag: "form",
-    classes: ["brsw-manual-popup", "application"],
-    window: { frame: false, positioned: false },
-  };
-
-  static PARTS = {
-    form: {
-      template: "modules/betterrolls-swade2/templates/manual_mods_popup.hbs",
-    }
-  };
-
-  static TRAIT_MODS = ["-8","-4","-2","-1","+1","+2","+4"];
-  static TRAIT_DICE = ["1","2","3","4","5","6"];
-  static DAMAGE_MODS = ["-2","-1","+1","+2","+4","+8"];
-
-  constructor(args) {
-    super(args);
-    game.brsw.manualModsPopup = this;
-    this.brCard = args.brCard;
-    this.anchorPosition = args.anchorPosition;
-  }
-
-  async _prepareContext(_options) {
-    const trait_mods = this.constructor.TRAIT_MODS.map((t) => ({ value: t, enabled: !!this.brCard.manual_mods?.trait_mods?.find((m) => t == m) }));
-    const trait_dice = this.constructor.TRAIT_DICE.map((t) => ({ value: t, enabled: t == this.brCard.manual_mods?.rof }));
-    const damage_mods = this.constructor.DAMAGE_MODS.map((t) => ({ value: t, enabled: !!this.brCard.manual_mods?.dmg_modifiers?.find((m) => t == m) }));
-    return {
-      trait: !!(this.brCard.trait),
-      damage: !!this.brCard.damage,
-      trait_mods: trait_mods,
-      trait_dice: trait_dice,
-      damage_mods: damage_mods,
+    static DEFAULT_OPTIONS = {
+        id: "manual-modifiers-popup",
+        tag: "form",
+        classes: ["brsw-manual-popup", "application"],
+        window: { frame: false, positioned: false },
     };
-  };
 
-  /**
- * Actions performed after any render of the Application.
- * Post-render steps are not awaited by the render process.
- * @param {ApplicationRenderContext} context      Prepared context data
- * @param {RenderOptions} options                 Provided render options
- * @protected
- */
-  _onRender(context, options) {
-    //Position the popup relative to the button
-    const { clientWidth, clientHeight } = document.documentElement;
-    this.element.style.bottom = `${clientHeight - this.anchorPosition.y}px`;
-    this.element.style.right = `${clientWidth - this.anchorPosition.x}px`;
-
-    //Close the popup if we click outside of it
-    document.addEventListener("click", this.clickListener = (event) => {
-      if (!event.composedPath().includes(this.element)) {
-        this.close();
-      }
-    }, { passive: true });
-
-    const modButtons = this.element.querySelectorAll(".brsw-selectable");
-    for (const modButton of modButtons) {
-      modButton.addEventListener("click", async event => {
-        this.onModifierSelected(event.target);
-      });
-    }
-  }
-
-  onModifierSelected(element) {
-    element.classList.toggle("brsw-selected");
-    const { type, value } = element.dataset;
-    this.brCard.manual_mods ??= {};
-    if (type == "modifier") {
-      this.brCard.manual_mods.trait_mods ??= [];
-      const modIdx = this.brCard.manual_mods.trait_mods.findIndex((m) => m == value);
-      if (modIdx >= 0) {
-        this.brCard.manual_mods.trait_mods.splice(modIdx, 1);
-      } else {
-        this.brCard.manual_mods.trait_mods.push(value);
-      }
-    } else if (type == "dmg_modifier") {
-      this.brCard.manual_mods.dmg_modifiers ??= [];
-      const modIdx = this.brCard.manual_mods.dmg_modifiers.findIndex((m) => m == value);
-      if (modIdx >= 0) {
-        this.brCard.manual_mods.dmg_modifiers.splice(modIdx, 1);
-      } else {
-        this.brCard.manual_mods.dmg_modifiers.push(value);
-      }
-    }else if (type == "rof") {
-      for (const rofEl of element.parentElement.querySelectorAll(`[data-type="rof"]`)) {
-        if (rofEl != element) {
-          rofEl.classList.remove("brsw-selected");
+    static PARTS = {
+        form: {
+            template: "modules/betterrolls-swade2/templates/manual_mods_popup.hbs",
         }
-      }
-      this.brCard.manual_mods.rof = element.classList.contains("brsw-selected") ? value : undefined;
-    }
-    this.brCard.save();
-  }
+    };
 
-  async close(options={}) {
-    options.animate ??= false;
-    await super.close(options);
-    document.removeEventListener("click", this.clickListener);
-    delete game.brsw.manualModsPopup;
-  }
+    static TRAIT_MODS = ["-8", "-4", "-2", "-1", "+1", "+2", "+4"];
+    static TRAIT_DICE = ["1", "2", "3", "4", "5", "6"];
+    static DAMAGE_MODS = ["-2", "-1", "+1", "+2", "+4", "+8"];
+
+    constructor(args) {
+        super(args);
+        game.brsw.manualModsPopup = this;
+        this.brCard = args.brCard;
+        this.anchorPosition = args.anchorPosition;
+    }
+
+    async _prepareContext(_options) {
+        const trait_mods = this.constructor.TRAIT_MODS.map((t) => ({ value: t, enabled: !!this.brCard.manual_mods?.trait_mods?.find((m) => t == m) }));
+        const trait_dice = this.constructor.TRAIT_DICE.map((t) => ({ value: t, enabled: t == this.brCard.manual_mods?.rof }));
+        const damage_mods = this.constructor.DAMAGE_MODS.map((t) => ({ value: t, enabled: !!this.brCard.manual_mods?.dmg_modifiers?.find((m) => t == m) }));
+        return {
+            trait: !!(this.brCard.trait),
+            damage: !!this.brCard.damage,
+            trait_mods: trait_mods,
+            trait_dice: trait_dice,
+            damage_mods: damage_mods,
+        };
+    };
+
+    /**
+   * Actions performed after any render of the Application.
+   * Post-render steps are not awaited by the render process.
+   * @param {ApplicationRenderContext} context      Prepared context data
+   * @param {RenderOptions} options                 Provided render options
+   * @protected
+   */
+    _onRender(context, options) {
+        //Position the popup relative to the button.
+        const { clientWidth, clientHeight } = document.documentElement;
+        const { width } = this.element.getBoundingClientRect();
+
+        let right = clientWidth - this.anchorPosition.x;
+        const bottom = clientHeight - this.anchorPosition.y;
+
+        //The popup normally extends to the left of the anchor.
+        //If that would put it outside the viewport, shift it to the right.
+        const left = this.anchorPosition.x - width;
+        if (left < 0) {
+            right += left;
+        }
+
+        this.element.style.bottom = `${bottom}px`;
+        this.element.style.right = `${right}px`;
+
+        //Close the popup if we click outside of it
+        document.addEventListener("click", this.clickListener = (event) => {
+            if (!event.composedPath().includes(this.element)) {
+                this.close();
+            }
+        }, { passive: true });
+
+        const modButtons = this.element.querySelectorAll(".brsw-selectable");
+        for (const modButton of modButtons) {
+            modButton.addEventListener("click", async event => {
+                this.onModifierSelected(event.target);
+            });
+        }
+    }
+
+    onModifierSelected(element) {
+        element.classList.toggle("brsw-selected");
+        const { type, value } = element.dataset;
+        this.brCard.manual_mods ??= {};
+        if (type == "modifier") {
+            this.brCard.manual_mods.trait_mods ??= [];
+            const modIdx = this.brCard.manual_mods.trait_mods.findIndex((m) => m == value);
+            if (modIdx >= 0) {
+                this.brCard.manual_mods.trait_mods.splice(modIdx, 1);
+            } else {
+                this.brCard.manual_mods.trait_mods.push(value);
+            }
+        } else if (type == "dmg_modifier") {
+            this.brCard.manual_mods.dmg_modifiers ??= [];
+            const modIdx = this.brCard.manual_mods.dmg_modifiers.findIndex((m) => m == value);
+            if (modIdx >= 0) {
+                this.brCard.manual_mods.dmg_modifiers.splice(modIdx, 1);
+            } else {
+                this.brCard.manual_mods.dmg_modifiers.push(value);
+            }
+        } else if (type == "rof") {
+            for (const rofEl of element.parentElement.querySelectorAll(`[data-type="rof"]`)) {
+                if (rofEl != element) {
+                    rofEl.classList.remove("brsw-selected");
+                }
+            }
+            this.brCard.manual_mods.rof = element.classList.contains("brsw-selected") ? value : undefined;
+        }
+        this.brCard.save();
+    }
+
+    async close(options = {}) {
+        options.animate ??= false;
+        await super.close(options);
+        document.removeEventListener("click", this.clickListener);
+        delete game.brsw.manualModsPopup;
+    }
 }

--- a/scripts/pp_management_dialog.js
+++ b/scripts/pp_management_dialog.js
@@ -152,7 +152,7 @@ export class PPManagementDialog extends HandlebarsApplicationMixin(ApplicationV2
       Object.assign(this.brCard.pp_modifiers, foundry.utils.deepClone(this.brCardOld.pp_modifiers));
     }
 
-    await super.close(options);
+    await super.close({ animate: false, ...options });
   }
 
   /**

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -20,13 +20,13 @@ import { SettingsUtils, Utils, addEventListenerAll } from "./utils.js";
  * @param {Number} type
  */
 async function createRemoveStatusCard(original_message, actor, type) {
-  let token_id;
+  let tokenId;
   if (original_message) {
     const originalCard = new BrCommonCard(original_message);
     actor = originalCard.actor;
-    token_id = originalCard.token.id;
+    tokenId = originalCard.token?.id ?? originalCard.token_id;
   } else if (actor) {
-    token_id = actor.token ? actor.token.id : actor.getActiveTokens()[0].id;
+    tokenId = actor.token ? actor.token.id : actor.getActiveTokens()[0].id;
   }
   if (!actor.system.status.isShaken && !actor.system.status.isStunned) {
     return;
@@ -60,7 +60,7 @@ async function createRemoveStatusCard(original_message, actor, type) {
   );
   brCard.update_list = { ...brCard.update_list, ...{ user: user.id } };
   brCard.type = type;
-  brCard.token_id = token_id;
+  brCard.token_id = tokenId;
   await brCard.render();
   return brCard.message;
 }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -337,7 +337,9 @@ function registerUserSettings() {
         hint: "BRSW.Settings.AllowDarkMode.Hint",
         default: false,
         type: Boolean,
-        onChange: () => {
+        onChange: (allow) => {
+            game.brsw.dialog.dialogElement.classList.toggle("brsw-allow-dark-mode", allow);
+
             const messages = game.messages.contents.filter(m => m.getFlag("betterrolls-swade2", "br_data"));
             for (const message of messages) {
                 ui.chat.updateMessage(message);

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -338,7 +338,7 @@ function registerUserSettings() {
         default: false,
         type: Boolean,
         onChange: (allow) => {
-            game.brsw.dialog.dialogElement.classList.toggle("brsw-allow-dark-mode", allow);
+            game.brsw.dialog?.dialogElement.classList.toggle("brsw-allow-dark-mode", allow);
 
             const messages = game.messages.contents.filter(m => m.getFlag("betterrolls-swade2", "br_data"));
             for (const message of messages) {

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -385,7 +385,7 @@ export class Utils {
                 if (index !== 0 && index !== words.length - 1 && minorWords.has(word)) {
                     return word;
                 }
-                return word.charAt(0).toUpperCase() + word.slice(1);
+                return word.split("/").map(part => part.charAt(0).toUpperCase() + part.slice(1)).join("/");
             }).join(" ");
     }
 

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -851,7 +851,7 @@ export class SettingsUtils {
     }
 
     static allowDarkMode() {
-        const userSettings = SettingsUtils.getModuleFlag(game.user, USER_FLAGS.userSettings);
+        const userSettings = SettingsUtils.getModuleFlag(game.user, USER_FLAGS.userSettings) ?? {};
         const key = USER_SETTING_KEYS.allowDarkMode;
         return userSettings[key] !== undefined
             ? userSettings[key]

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -170,10 +170,20 @@ export async function simple_form(title, fields, callback) {
 }
 
 /**
+ * Gets the user's list of targets
+ */
+export function getUserTargets() {
+    if (game.user.targets.size || !game.brsw.targetIds?.length) {
+        return Array.from(game.user.targets).map(t => Utils.toTokenDoc(t));
+    }
+    return game.brsw.targetIds.map(t => fromUuidSync(t)).filter(Boolean);
+}
+
+/**
  * Gets the first targeted token
  */
 export function getTargetedToken(originActors) {
-    return game.user.targets.first() ?? getSelectedToken(originActors);
+    return getUserTargets()[0] ?? getSelectedToken(originActors);
 }
 
 /**
@@ -181,7 +191,7 @@ export function getTargetedToken(originActors) {
  */
 export function getSelectedToken(originActors) {
     const originActorIds = new Set(originActors?.map(a => a.id) ?? []);
-    return canvas.tokens.controlled.find((t) => t.actor && !originActorIds.has(t.actor.id));
+    return Utils.toTokenDoc(canvas.tokens?.controlled.find((t) => t.actor && !originActorIds.has(t.actor.id)));
 }
 
 /**

--- a/templates/common_card_header.hbs
+++ b/templates/common_card_header.hbs
@@ -9,7 +9,7 @@
     {{/if}}
     <div class="brsw-header-title-wrapper">
         <span class="brsw-header-title-group">
-            <a class="brsw-collapse-button brsw-header-title" data-collapse="brsw-description">{{header.title}}</a>
+            <a class="{{#if description}}brsw-collapse-button{{/if}} brsw-header-title" data-collapse="brsw-description">{{header.title}}</a>
             {{#if showTools}}
                 <span class="brsw-common-tools brsw-form">
                     {{#if showRepeat}}

--- a/templates/damage_partial.hbs
+++ b/templates/damage_partial.hbs
@@ -1,71 +1,75 @@
-{{#each damage_rolls}}
-    {{#with (lookup this.brswroll.rolls 0) as | roll |}}
-        <div class="brsw-damage-roll-row">
-            <span class="brsw-damage-roll-target brsw-clickable brsw-collapse-button" data-collapse="brsw-damage-detail{{@index}}" data-target="{{roll.target_id}}">
-                {{../label}}:
-            </span>
-            <span class="brsw-damage-roll-damage">
-                <span class="{{roll.extra_class}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
-                <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
-                        {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
-                        {{#unless ../../bennie_available}}disabled{{/unless}}>
-                    <img src="{{{../../benny_image}}}" class="brsw-button-image" alt="Reroll with benny">
-                </button>
-            </span>
-            <span class="brsw-damage-roll-result {{#if ../result_master_only}} brsw-master-only{{/if}}">
-                <span title="{{roll.result_text}}" class="brsw-result-icon">
-                    {{{roll.result_icon}}}
-                </span>
-                <button class="brsw-apply-damage brsw-master-only" disabled
-                        data-target="{{roll.target_id}}" data-damage="{{../damageResult}}" data-heavy-damage="{{../../item.system.isHeavyWeapon}}">
-                    <i class="fas fa-check"></i>
-                </button>
-            </span>
-        </div>
-        <div class="brsw-damage-detail{{@index}} brsw-collapsed">
-            <div class="brsw-roll-detail-row">
-                <span>
-                </span>
-                <span>
-                    <span class="brsw-form brsw-clickable brsw-half-damage" title="{{localize 'BRSW.HalfDamage'}}" data-index="{{@index}}">
-                        <i class="fas fa-shield-alt"></i>
+<div class="brsw-damage-rows">
+    {{#each damage_rolls}}
+        {{#with (lookup this.brswroll.rolls 0) as | roll |}}
+            <div class="brsw-damage-group">
+                <div class="brsw-damage-roll-row">
+                    <span class="brsw-damage-roll-target brsw-clickable brsw-collapse-button" data-collapse="brsw-damage-detail{{@index}}" data-target="{{roll.target_id}}">
+                        {{../label}}:
                     </span>
-                    <span class="brsw-form brsw-clickable brsw-add-damage-number" data-index="{{@index}}" title="{{localize 'BRSW.AddDamage'}}">
-                        <i class="fas fa-plus"></i> <i class="fas fa-scroll"></i>
+                    <span class="brsw-damage-roll-damage">
+                        <span class="{{roll.extra_class}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
+                        <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
+                                {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
+                                {{#unless ../../bennie_available}}disabled{{/unless}}>
+                            <img src="{{{../../benny_image}}}" class="brsw-button-image" alt="Reroll with benny">
+                        </button>
                     </span>
-                    <span class="brsw-form brsw-clickable brsw-add-damage-d6" data-index="{{@index}}" title="{{localize 'BRSW.AddD6Damage'}}">
-                        <i class="fas fa-plus"></i> <i class="fas fa-dice-six"></i>
-                    </span>
-                    <i class="brsw-target-tough brsw-clickable fas fa-bullseye brsw-form" data-index="{{@index}}" title="{{localize 'BRSW.TGTargetSelected'}}"></i>
-                </span>
-            </div>
-            {{#each ../brswroll.dice as |current_dice|}}
-                <div class="brsw-roll-detail-row {{this.extra_class}}">
-                    <span>{{this.label}}</span>
-                    <span>{{#each this.results}}
-                            <span class="brsw-d{{current_dice.faces}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
-                        {{/each}}</span>
-                </div>
-            {{/each}}
-            {{#each ../brswroll.modifiers}}
-                <div class="brsw-roll-detail-row {{this.extra_class}}">
-                    <span>{{this.name}}</span>
-                    {{#if this.dice}}
-                        <span>{{#each this.dice.terms as |current_term|}}
-                                {{#each this.results}}
-                                    <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
-                                {{/each}}
-                            {{/each}}</span>
-                    {{else}}
-                        <span>
-                            {{this.value}}
+                    <span class="brsw-damage-roll-result {{#if ../result_master_only}} brsw-master-only{{/if}}">
+                        <span title="{{roll.result_text}}" class="brsw-result-icon">
+                            {{{roll.result_icon}}}
                         </span>
-                    {{/if}}
+                        <button class="brsw-apply-damage brsw-master-only" disabled
+                                data-target="{{roll.target_id}}" data-damage="{{../damageResult}}" data-heavy-damage="{{../../item.system.isHeavyWeapon}}">
+                            <i class="fas fa-check"></i>
+                        </button>
+                    </span>
                 </div>
-            {{/each}}
-            <div class="brsw-damage-calculation">
-                {{localize "SWADE.Tough"}} {{roll.tn}}, {{localize "SWADE.APLong"}} {{roll.ap}}, {{localize "SWADE.Armor"}} {{roll.armor}}
+                <div class="brsw-damage-detail{{@index}} brsw-collapsed">
+                    <div class="brsw-roll-detail-row">
+                        <span>
+                        </span>
+                        <span>
+                            <span class="brsw-form brsw-clickable brsw-half-damage" title="{{localize 'BRSW.HalfDamage'}}" data-index="{{@index}}">
+                                <i class="fas fa-shield-alt"></i>
+                            </span>
+                            <span class="brsw-form brsw-clickable brsw-add-damage-number" data-index="{{@index}}" title="{{localize 'BRSW.AddDamage'}}">
+                                <i class="fas fa-plus"></i> <i class="fas fa-scroll"></i>
+                            </span>
+                            <span class="brsw-form brsw-clickable brsw-add-damage-d6" data-index="{{@index}}" title="{{localize 'BRSW.AddD6Damage'}}">
+                                <i class="fas fa-plus"></i> <i class="fas fa-dice-six"></i>
+                            </span>
+                            <i class="brsw-target-tough brsw-clickable fas fa-bullseye brsw-form" data-index="{{@index}}" title="{{localize 'BRSW.TGTargetSelected'}}"></i>
+                        </span>
+                    </div>
+                    {{#each ../brswroll.dice as |current_dice|}}
+                        <div class="brsw-roll-detail-row {{this.extra_class}}">
+                            <span>{{this.label}}</span>
+                            <span>{{#each this.results}}
+                                    <span class="brsw-d{{current_dice.faces}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
+                                {{/each}}</span>
+                        </div>
+                    {{/each}}
+                    {{#each ../brswroll.modifiers}}
+                        <div class="brsw-roll-detail-row {{this.extra_class}}">
+                            <span>{{this.name}}</span>
+                            {{#if this.dice}}
+                                <span>{{#each this.dice.terms as |current_term|}}
+                                        {{#each this.results}}
+                                            <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
+                                        {{/each}}
+                                    {{/each}}</span>
+                            {{else}}
+                                <span>
+                                    {{this.value}}
+                                </span>
+                            {{/if}}
+                        </div>
+                    {{/each}}
+                    <div class="brsw-damage-calculation">
+                        {{localize "SWADE.Tough"}} {{roll.tn}}, {{localize "SWADE.APLong"}} {{roll.ap}}, {{localize "SWADE.Armor"}} {{roll.armor}}
+                    </div>
+                </div>
             </div>
-        </div>
-    {{/with}}
-{{/each}}
+        {{/with}}
+    {{/each}}
+</div>

--- a/templates/damage_partial.hbs
+++ b/templates/damage_partial.hbs
@@ -1,73 +1,71 @@
 <div class="brsw-damage-rows">
     {{#each damage_rolls}}
         {{#with (lookup this.brswroll.rolls 0) as | roll |}}
-            <div class="brsw-damage-group">
-                <div class="brsw-damage-roll-row">
-                    <span class="brsw-damage-roll-target brsw-clickable brsw-collapse-button" data-collapse="brsw-damage-detail{{@index}}" data-target="{{roll.target_id}}">
-                        {{../label}}:
+            <div class="brsw-damage-roll-row">
+                <span class="brsw-damage-roll-target brsw-clickable brsw-collapse-button" data-collapse="brsw-damage-detail{{@index}}" data-target="{{roll.target_id}}">
+                    {{../label}}
+                </span>
+                <span class="brsw-damage-roll-damage">
+                    <span class="{{roll.extra_class}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
+                    <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
+                            {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
+                            {{#unless ../../bennie_available}}disabled{{/unless}}>
+                        <img src="{{{../../benny_image}}}" class="brsw-button-image" alt="Reroll with benny">
+                    </button>
+                </span>
+                <span class="brsw-damage-roll-result {{#if ../result_master_only}} brsw-master-only{{/if}}">
+                    <span title="{{roll.result_text}}" class="brsw-result-icon">
+                        {{{roll.result_icon}}}
                     </span>
-                    <span class="brsw-damage-roll-damage">
-                        <span class="{{roll.extra_class}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
-                        <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
-                                {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
-                                {{#unless ../../bennie_available}}disabled{{/unless}}>
-                            <img src="{{{../../benny_image}}}" class="brsw-button-image" alt="Reroll with benny">
-                        </button>
+                    <button class="brsw-apply-damage brsw-master-only" disabled
+                            data-target="{{roll.target_id}}" data-damage="{{../damageResult}}" data-heavy-damage="{{../../item.system.isHeavyWeapon}}">
+                        <i class="fas fa-check"></i>
+                    </button>
+                </span>
+            </div>
+            <div class="brsw-damage-detail brsw-damage-detail{{@index}} brsw-collapsed">
+                <div class="brsw-roll-detail-row">
+                    <span>
                     </span>
-                    <span class="brsw-damage-roll-result {{#if ../result_master_only}} brsw-master-only{{/if}}">
-                        <span title="{{roll.result_text}}" class="brsw-result-icon">
-                            {{{roll.result_icon}}}
+                    <span>
+                        <span class="brsw-form brsw-clickable brsw-half-damage" title="{{localize 'BRSW.HalfDamage'}}" data-index="{{@index}}">
+                            <i class="fas fa-shield-alt"></i>
                         </span>
-                        <button class="brsw-apply-damage brsw-master-only" disabled
-                                data-target="{{roll.target_id}}" data-damage="{{../damageResult}}" data-heavy-damage="{{../../item.system.isHeavyWeapon}}">
-                            <i class="fas fa-check"></i>
-                        </button>
+                        <span class="brsw-form brsw-clickable brsw-add-damage-number" data-index="{{@index}}" title="{{localize 'BRSW.AddDamage'}}">
+                            <i class="fas fa-plus"></i> <i class="fas fa-scroll"></i>
+                        </span>
+                        <span class="brsw-form brsw-clickable brsw-add-damage-d6" data-index="{{@index}}" title="{{localize 'BRSW.AddD6Damage'}}">
+                            <i class="fas fa-plus"></i> <i class="fas fa-dice-six"></i>
+                        </span>
+                        <i class="brsw-target-tough brsw-clickable fas fa-bullseye brsw-form" data-index="{{@index}}" title="{{localize 'BRSW.TGTargetSelected'}}"></i>
                     </span>
                 </div>
-                <div class="brsw-damage-detail{{@index}} brsw-collapsed">
-                    <div class="brsw-roll-detail-row">
-                        <span>
-                        </span>
-                        <span>
-                            <span class="brsw-form brsw-clickable brsw-half-damage" title="{{localize 'BRSW.HalfDamage'}}" data-index="{{@index}}">
-                                <i class="fas fa-shield-alt"></i>
-                            </span>
-                            <span class="brsw-form brsw-clickable brsw-add-damage-number" data-index="{{@index}}" title="{{localize 'BRSW.AddDamage'}}">
-                                <i class="fas fa-plus"></i> <i class="fas fa-scroll"></i>
-                            </span>
-                            <span class="brsw-form brsw-clickable brsw-add-damage-d6" data-index="{{@index}}" title="{{localize 'BRSW.AddD6Damage'}}">
-                                <i class="fas fa-plus"></i> <i class="fas fa-dice-six"></i>
-                            </span>
-                            <i class="brsw-target-tough brsw-clickable fas fa-bullseye brsw-form" data-index="{{@index}}" title="{{localize 'BRSW.TGTargetSelected'}}"></i>
-                        </span>
+                {{#each ../brswroll.dice as |current_dice|}}
+                    <div class="brsw-roll-detail-row {{this.extra_class}}">
+                        <span>{{this.label}}</span>
+                        <span>{{#each this.results}}
+                                <span class="brsw-d{{current_dice.faces}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
+                            {{/each}}</span>
                     </div>
-                    {{#each ../brswroll.dice as |current_dice|}}
-                        <div class="brsw-roll-detail-row {{this.extra_class}}">
-                            <span>{{this.label}}</span>
-                            <span>{{#each this.results}}
-                                    <span class="brsw-d{{current_dice.faces}} brsw-dice-image" data-text="{{this}}">{{this}}</span>
+                {{/each}}
+                {{#each ../brswroll.modifiers}}
+                    <div class="brsw-roll-detail-row {{this.extra_class}}">
+                        <span>{{this.name}}</span>
+                        {{#if this.dice}}
+                            <span>{{#each this.dice.terms as |current_term|}}
+                                    {{#each this.results}}
+                                        <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
+                                    {{/each}}
                                 {{/each}}</span>
-                        </div>
-                    {{/each}}
-                    {{#each ../brswroll.modifiers}}
-                        <div class="brsw-roll-detail-row {{this.extra_class}}">
-                            <span>{{this.name}}</span>
-                            {{#if this.dice}}
-                                <span>{{#each this.dice.terms as |current_term|}}
-                                        {{#each this.results}}
-                                            <span class="brsw-d{{current_term.faces}} brsw-dice-image" data-text="{{this.result}}">{{this.result}}</span>
-                                        {{/each}}
-                                    {{/each}}</span>
-                            {{else}}
-                                <span>
-                                    {{this.value}}
-                                </span>
-                            {{/if}}
-                        </div>
-                    {{/each}}
-                    <div class="brsw-damage-calculation">
-                        {{localize "SWADE.Tough"}} {{roll.tn}}, {{localize "SWADE.APLong"}} {{roll.ap}}, {{localize "SWADE.Armor"}} {{roll.armor}}
+                        {{else}}
+                            <span>
+                                {{this.value}}
+                            </span>
+                        {{/if}}
                     </div>
+                {{/each}}
+                <div class="brsw-damage-calculation">
+                    {{localize "SWADE.Tough"}} {{roll.tn}}, {{localize "SWADE.Armor"}} {{roll.armor}}, {{localize "BRSW.ApShort"}} {{roll.ap}}
                 </div>
             </div>
         {{/with}}

--- a/templates/item_card.hbs
+++ b/templates/item_card.hbs
@@ -85,7 +85,7 @@
         {{>"modules/betterrolls-swade2/templates/damage_partial.hbs"}}
     </div>
     {{#if swade_templates}}
-        <div class="brsw-form">
+        <div class="brsw-form brsw-swade-templates">
             <h4 class="brsw-item-subheading">
                 <i class="fa-solid fa-ruler-combined"></i> {{localize 'BRSW.Templates'}}
             </h4>
@@ -109,7 +109,7 @@
     {{/if}}
     {{#if hasFooterButtons}}
         {{#if macro_buttons}}
-            <div class="brsw-form">
+            <div class="brsw-form brsw-macro-buttons">
                 <h4 class="brsw-item-subheading">
                     <i class="fa-solid fa-code"></i> {{localize 'BRSW.Macros'}}
                 </h4>
@@ -121,7 +121,7 @@
             </div>
         {{/if}}
         {{#if resist_buttons}}
-            <div>
+            <div class="brsw-form brsw-resist-buttons">
                 <h4 class="brsw-item-subheading">
                     <i class="fa-solid fa-ban"></i> {{localize 'BRSW.Resistance'}}
                 </h4>

--- a/templates/manual_mods_popup.hbs
+++ b/templates/manual_mods_popup.hbs
@@ -3,24 +3,30 @@
         {{#if trait}}
             <div class="brsw-common-modifiers brsw-player-modifiers">
                 <span id="brsw-mods-Trait-label">{{localize "BRSW.TraitModifier"}}:</span>
-                {{#each trait_mods}}
-                    <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="modifier" data-value="{{value}}">{{value}}</span>
-                {{/each}}
+                <div>
+                    {{#each trait_mods}}
+                        <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="modifier" data-value="{{value}}">{{value}}</span>
+                    {{/each}}
+                </div>
             </div>
 
             <div class="brsw-common-modifiers brsw-player-modifiers">
                 <span id="brsw-mods-ROF-label">{{localize "BRSW.NumberTraitDice"}}:</span>
-                {{#each trait_dice}}
-                    <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="rof" data-value="{{value}}">{{value}}</span>
-                {{/each}}
+                <div>
+                    {{#each trait_dice}}
+                        <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="rof" data-value="{{value}}">{{value}}</span>
+                    {{/each}}
+                </div>
             </div>
         {{/if}}
         {{#if damage}}
             <div class="brsw-common-modifiers brsw-player-modifiers">
                 <span id="brsw-mods-Damage-label">{{localize "BRSW.DmgModifier"}}:</span>
-                {{#each damage_mods}}
-                    <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="dmg_modifier" data-value="{{value}}">{{value}}</span>
-                {{/each}}
+                <div>
+                    {{#each damage_mods}}
+                        <span class="brsw-selectable brsw-clickable{{#if enabled}} brsw-selected{{/if}}" data-type="dmg_modifier" data-value="{{value}}">{{value}}</span>
+                    {{/each}}
+                </div>
             </div>
         {{/if}}
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Refine chat card rendering and targeting behaviour, improve damage and modifier UI layout, and add better support for dark mode and player/pilot targeting scenarios.

New Features:
- Expose card listener and decoration helpers through the public API for use by other modules.
- Add a unified getUserTargets helper to support alternative target sources such as player/pilot tokens.
- Introduce more responsive and mobile-friendly layouts for the card dialog and damage rows.

Bug Fixes:
- Prevent errors when creating damage and item cards if no canvas or tokens are available.
- Ensure heavy armor checks and status removal cards work reliably regardless of token document shape or missing tokens.
- Make PP management dialog closing consistent by disabling animation by default.
- Avoid making header titles look interactive when no description is present.

Enhancements:
- Refactor chat card decoration into a reusable decorateCardHTML function and reuse it across render hooks.
- Improve damage target name and header title font fitting using layout-aware sizing and resize observers.
- Rework damage partial markup and styles to use CSS grid, simplifying alignment and making target text wrapping more robust.
- Adjust manual modifiers popup positioning to keep it within the viewport and nest modifier buttons for better alignment.
- Make card dialog respect user dark mode settings and apply parchment styling in dark themes with improved contrast.
- Tighten various CSS styles for common modifiers, buttons, and sections, including template, macro, and resistance blocks.