### PR TITLE
Button spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-# Version 5.21.1
+# Version 5.22.0
 * Vehicle items now use the vehicles roll data when rolling damage. This basically does nothing at the moment but will fix an issue once the swade system is updated.
+* Fixed an issue when editing modifiers
+* Added a spinner to buttons when rolling and waiting for the result
 
 # Version 5.21.0
 * Added dark mode support. It can be disabled in the user settings independent of the Foundry UI setting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 # Version 5.22.0
-* Vehicle items now use the vehicles roll data when rolling damage. This basically does nothing at the moment but will fix an issue once the swade system is updated.
+* Vehicle items now use the vehicle's roll data when rolling damage. This basically does nothing at the moment but will fix an issue once the swade system is updated.
 * Fixed an issue when editing modifiers
 * Added a spinner to buttons when rolling and waiting for the result
 

--- a/css/brsw-styles.css
+++ b/css/brsw-styles.css
@@ -1428,3 +1428,27 @@
     color: white;
     background-color: var(--brsw-color-gray-700);
 }
+
+/* Button spinner */
+
+.brsw-button-loading {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.brsw-button-spinner {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    border: 2px solid var(--brsw-button-color, black);
+    border-right-color: transparent;
+    border-radius: 50%;
+    animation: brsw-button-spin 0.6s linear infinite;
+}
+
+@keyframes brsw-button-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}

--- a/scripts/attribute_card.js
+++ b/scripts/attribute_card.js
@@ -1,16 +1,15 @@
 // Functions for cards representing attributes
-/* global TokenDocument, Token, game, CONST, $ */
 
-import { BrCommonCard } from "./BrCommonCard.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 import {
-  create_common_card,
-  getActionFromClick,
-  getActorFromIds,
-  process_common_actions,
-  roll_trait,
-  spendBenny,
-  traitToDieString,
+    create_common_card,
+    getActionFromClick,
+    getActorFromIds,
+    process_common_actions,
+    roll_trait,
+    spendBenny,
+    traitToDieString,
+    withButtonSpinner,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
@@ -25,24 +24,24 @@ import { Utils, addEventListenerAll } from "./utils.js";
  * @return {Promise} A promise for the BrCommonCard object
  */
 async function createAttributeCard(origin, name, { actions_stored = {} } = {},) {
-  const actor = Utils.toActor(origin);
+    const actor = Utils.toActor(origin);
 
-  const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
-  const title = translatedName + " " + traitToDieString(actor.system.attributes[name.toLowerCase()]);
+    const translatedName = game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[name]);
+    const title = translatedName + " " + traitToDieString(actor.system.attributes[name.toLowerCase()]);
 
-  const brCard = create_common_card(
-    origin,
-    {
-      header: { type: game.i18n.localize("BRSW.Attribute"), title: title },
-      trait: Utils.traitFromString(actor, translatedName),
-    },
-    "modules/betterrolls-swade2/templates/attribute_card.hbs",
-  );
+    const brCard = create_common_card(
+        origin,
+        {
+            header: { type: game.i18n.localize("BRSW.Attribute"), title: title },
+            trait: Utils.traitFromString(actor, translatedName),
+        },
+        "modules/betterrolls-swade2/templates/attribute_card.hbs",
+    );
 
-  brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD;
+    brCard.type = BRSW2_CONST.BRSW_CARD_TYPES.TYPE_ATTRIBUTE_CARD;
 
-  await brCard.render(actions_stored);
-  return brCard;
+    await brCard.render(actions_stored);
+    return brCard;
 }
 
 /**
@@ -58,24 +57,24 @@ async function createAttributeCard(origin, name, { actions_stored = {} } = {},) 
  * @return {Promise} a promise for the ChatMessage object
  */
 function createAttributeCardFromId(
-  token_id,
-  actor_id,
-  name,
-  { actions_stored = {} } = {},
+    token_id,
+    actor_id,
+    name,
+    { actions_stored = {} } = {},
 ) {
-  const actor = getActorFromIds(token_id, actor_id);
-  return createAttributeCard(actor, name, {
-    actions_stored: actions_stored,
-  });
+    const actor = getActorFromIds(token_id, actor_id);
+    return createAttributeCard(actor, name, {
+        actions_stored: actions_stored,
+    });
 }
 
 /**
  * Hooks the public functions to a global object
  */
 export function exposeAttributeAPI() {
-  Utils.exposeAPI("createAttributeCard", createAttributeCard, "create_atribute_card");
-  Utils.exposeAPI("createAttributeCardFromId", createAttributeCardFromId, "create_attribute_card_from_id");
-  Utils.exposeAPI("rollAttribute", rollAttribute, "roll_attribute");
+    Utils.exposeAPI("createAttributeCard", createAttributeCard, "create_atribute_card");
+    Utils.exposeAPI("createAttributeCardFromId", createAttributeCardFromId, "create_attribute_card_from_id");
+    Utils.exposeAPI("rollAttribute", rollAttribute, "roll_attribute");
 }
 
 /**
@@ -84,22 +83,22 @@ export function exposeAttributeAPI() {
  * @param {SwadeActor, Token} target token or actor from the char sheet
  */
 async function attribute_click_listener(ev, target) {
-  const action = getActionFromClick(ev);
-  if (action === "system") {
-    return;
-  }
-  ev.stopImmediatePropagation();
-  ev.preventDefault();
-  ev.stopPropagation();
-  // The attribute id placement is sheet dependent.
-  const attribute_id = ev.currentTarget.dataset.attribute;
-  // Show card
-  const brCard = await createAttributeCard(target, attribute_id);
-  if (action.includes("dialog")) {
-    game.brsw.dialog.show_card(brCard);
-  } else if (action.includes("trait")) {
-    await rollAttribute(brCard, false);
-  }
+    const action = getActionFromClick(ev);
+    if (action === "system") {
+        return;
+    }
+    ev.stopImmediatePropagation();
+    ev.preventDefault();
+    ev.stopPropagation();
+    // The attribute id placement is sheet dependent.
+    const attribute_id = ev.currentTarget.dataset.attribute;
+    // Show card
+    const brCard = await createAttributeCard(target, attribute_id);
+    if (action.includes("dialog")) {
+        game.brsw.dialog.show_card(brCard);
+    } else if (action.includes("trait")) {
+        await rollAttribute(brCard, false);
+    }
 }
 
 /**
@@ -108,10 +107,10 @@ async function attribute_click_listener(ev, target) {
  * @param html Html code
  */
 export function activate_attribute_listeners(app, html) {
-  const target = app.token || app.actor || app.object;
-  addEventListenerAll(html, ".attribute-value", "click", async (ev) => {
-    await attribute_click_listener(ev, target);
-  }, true);
+    const target = app.token || app.actor || app.object;
+    addEventListenerAll(html, ".attribute-value", "click", async (ev) => {
+        await attribute_click_listener(ev, target);
+    }, true);
 }
 
 /**
@@ -120,16 +119,18 @@ export function activate_attribute_listeners(app, html) {
  * @param html Html produced
  */
 export function activateAttributeCardListeners(card, html) {
-  const roll_buttons = html.querySelectorAll(".brsw-roll-button");
-  for (const roll_button of roll_buttons) {
-    roll_button.addEventListener("click", async (ev) => {
-      ev.stopPropagation();
-      await rollAttribute(
-        card,
-        ev.currentTarget.classList.contains("roll-bennie-button"),
-      );
-    });
-  }
+    const roll_buttons = html.querySelectorAll(".brsw-roll-button");
+    for (const roll_button of roll_buttons) {
+        roll_button.addEventListener("click", async (ev) => {
+            ev.stopPropagation();
+            await withButtonSpinner(ev.currentTarget, () =>
+                rollAttribute(
+                    card,
+                    ev.currentTarget.classList.contains("roll-bennie-button"),
+                ),
+            );
+        });
+    }
 }
 
 /**
@@ -139,23 +140,23 @@ export function activateAttributeCardListeners(card, html) {
  * @param {boolean} expendBenny True if we want to spend a bennie
  */
 export async function rollAttribute(brCard, expendBenny) {
-  const extraData = { modifiers: [] };
-  const macros = [];
-  for (const action of brCard.getSelectedActions()) {
-    process_common_actions(action.code, extraData, macros, brCard.actor);
-  }
-  if (brCard.trait_roll.is_rolled) {
-    brCard.trait_roll.reroll_mode = expendBenny ? "benny" : "free";
-  }
-  if (expendBenny) {
-    await spendBenny(brCard.actor);
-  }
-  await roll_trait(
-    brCard,
-    brCard.actor.system.attributes[brCard.attribute],
-    game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[brCard.attribute]),
-    extraData,
-  );
-  // noinspection ES6MissingAwait
-  runMacros(macros, brCard);
+    const extraData = { modifiers: [] };
+    const macros = [];
+    for (const action of brCard.getSelectedActions()) {
+        process_common_actions(action.code, extraData, macros, brCard.actor);
+    }
+    if (brCard.trait_roll.is_rolled) {
+        brCard.trait_roll.reroll_mode = expendBenny ? "benny" : "free";
+    }
+    if (expendBenny) {
+        await spendBenny(brCard.actor);
+    }
+    await roll_trait(
+        brCard,
+        brCard.actor.system.attributes[brCard.attribute],
+        game.i18n.localize(BRSW2_CONST.ATTRIBUTES_TRANSLATION_KEYS[brCard.attribute]),
+        extraData,
+    );
+    // noinspection ES6MissingAwait
+    runMacros(macros, brCard);
 }

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -1,7 +1,4 @@
 // Common functions used in all cards
-/* globals game, Token, TokenDocument, Roll, canvas, console, $, foundry,
-      duplicate, ChatMessage, ui, Macro */
-// noinspection JSUnusedAssignment
 
 import { BrCommonCard } from "./BrCommonCard.js";
 import { rollAttribute } from "./attribute_card.js";
@@ -1419,5 +1416,51 @@ function apply_aiming_ignore(extraData) {
         if (extraData.total_aiming_ignorable_penalties === 0) {
             break;
         }
+    }
+}
+
+/**
+ * @param {HTMLElement} button The button to show the spinner on
+ */
+function addSpinnerToButton(button) {
+    if (!button || button.classList.contains("brsw-button-loading")) {
+        //Already spinning, so probably a double click. Ignore
+        return;
+    }
+    button.dataset.brswOriginalContent = button.innerHTML;
+    button.innerHTML = '<span class="brsw-button-spinner"></span>';
+    button.classList.add("brsw-button-loading");
+}
+
+/**
+ * @param {HTMLElement} button The button to remove the spinner from
+ */
+function removeSpinnerFromButton(button) {
+    if (!button || !button.classList.contains("brsw-button-loading")) {
+        return;
+    }
+    button.classList.remove("brsw-button-loading");
+    if (button.dataset.brswOriginalContent !== undefined) {
+        button.innerHTML = button.dataset.brswOriginalContent;
+        delete button.dataset.brswOriginalContent;
+    }
+}
+
+/**
+ * Wraps an async action with a loading spinner on the button that triggered it.
+ * @param {HTMLElement} button The button that was clicked
+ * @param {Function} action A function (sync or async) to execute
+ * @returns {Promise} The result of action()
+ */
+export async function withButtonSpinner(button, action) {
+    if (!button || button.classList.contains("brsw-button-loading")) {
+        //Already spinning, so probably a double click. Ignore
+        return;
+    }
+    addSpinnerToButton(button);
+    try {
+        await action();
+    } finally {
+        removeSpinnerFromButton(button);
     }
 }

--- a/scripts/damage_card.js
+++ b/scripts/damage_card.js
@@ -7,6 +7,7 @@ import {
     create_common_card,
     roll_trait,
     spendBenny,
+    withButtonSpinner,
 } from "./cards_common.js";
 import {
     createIncapacitationCard,
@@ -228,7 +229,7 @@ export function activateDamageCardListeners(message, html) {
         ) {
             spendBenny = true;
         }
-        rollSoak(brCard, spendBenny);
+        withButtonSpinner(ev.currentTarget, () => rollSoak(brCard, spendBenny));
     });
     html.querySelector(".brsw-show-incapacitation")?.addEventListener("click", () => {
         brCard.closePopout(); //We assume we're done with the card at this point so close any popouts

--- a/scripts/incapacitation_card.js
+++ b/scripts/incapacitation_card.js
@@ -1,13 +1,12 @@
 // functions for the incapacitation card
-/* globals canvas, game, CONST, Roll, Hooks, succ, fromUuid, console */
 
 import { BrCommonCard } from "./BrCommonCard.js";
-import * as BRSW2_CONFIG from "./brsw2-config.js";
 import { BRSW2_CONST } from "./brsw2-const.js";
 import {
     create_common_card,
     roll_trait,
     spendBenny,
+    withButtonSpinner,
 } from "./cards_common.js";
 import { get_owner } from "./damage_card.js";
 import { Utils, addEventListenerAll } from "./utils.js";
@@ -67,7 +66,9 @@ function roll_incapacitation_clicked(ev, brCard) {
         spendBenny = true;
     }
     // noinspection JSIgnoredPromiseFromCall
-    roll_incapacitation(brCard, spendBenny);
+    withButtonSpinner(ev.currentTarget, () =>
+        roll_incapacitation(brCard, spendBenny),
+    );
 }
 
 /**

--- a/scripts/item_card.js
+++ b/scripts/item_card.js
@@ -21,6 +21,7 @@ import {
     roll_trait,
     spendBenny,
     update_message,
+    withButtonSpinner,
 } from "./cards_common.js";
 import { createDamageCard } from "./damage_card.js";
 import { DamageModifier, TraitModifier } from "./modifiers.js";
@@ -458,10 +459,12 @@ export function activateItemCardListeners(brCard, html) {
 
     addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
         ev.stopPropagation();
-        await rollItem(
-            brCard,
-            html,
-            ev.currentTarget.classList.contains("roll-bennie-button"),
+        await withButtonSpinner(ev.currentTarget, () =>
+            rollItem(
+                brCard,
+                html,
+                ev.currentTarget.classList.contains("roll-bennie-button"),
+            ),
         );
     });
 
@@ -471,13 +474,15 @@ export function activateItemCardListeners(brCard, html) {
         "click",
         (ev) => {
             // noinspection JSIgnoredPromiseFromCall
-            roll_dmg(
-                brCard,
-                html,
-                ev.currentTarget.classList.contains("brsw-damage-bennie-button"),
-                {},
-                ev.currentTarget.id.includes("raise"),
-                ev.currentTarget.dataset.target,
+            withButtonSpinner(ev.currentTarget, () =>
+                roll_dmg(
+                    brCard,
+                    html,
+                    ev.currentTarget.classList.contains("brsw-damage-bennie-button"),
+                    {},
+                    ev.currentTarget.id.includes("raise"),
+                    ev.currentTarget.dataset.target,
+                ),
             );
         },
     );

--- a/scripts/remove_status_cards.js
+++ b/scripts/remove_status_cards.js
@@ -8,6 +8,7 @@ import {
   create_common_card,
   roll_trait,
   spendBenny,
+  withButtonSpinner,
 } from "./cards_common.js";
 import { get_owner } from "./damage_card.js";
 import { TraitModifier } from "./modifiers.js";
@@ -109,7 +110,7 @@ export function activateRemoveStatusCardListeners(
       spendBenny = true;
     }
     // noinspection JSIgnoredPromiseFromCall
-    roll_function(brCard, spendBenny);
+    withButtonSpinner(ev.currentTarget, () => roll_function(brCard, spendBenny));
   });
 }
 

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -10,6 +10,7 @@ import {
     roll_trait,
     spendBenny,
     traitToDieString,
+    withButtonSpinner,
 } from "./cards_common.js";
 import { runMacros } from "./item_card.js";
 import { TraitModifier } from "./modifiers.js";
@@ -147,9 +148,11 @@ export function activate_skill_listeners(app, html) {
 export function activateSkillCardListeners(brCard, html) {
     addEventListenerAll(html, ".brsw-roll-button", "click", async (ev) => {
         ev.stopPropagation();
-        await rollSkill(
-            brCard,
-            ev.currentTarget.classList.contains("roll-bennie-button"),
+        await withButtonSpinner(ev.currentTarget, () =>
+            rollSkill(
+                brCard,
+                ev.currentTarget.classList.contains("roll-bennie-button"),
+            ),
         );
     });
     html.querySelector(".brsw-header-img").addEventListener("click", (_) => {


### PR DESCRIPTION
## Summary by Sourcery

Add visual loading feedback to roll-related buttons across cards and update version metadata.

Enhancements:
- Introduce a reusable withButtonSpinner helper to wrap async button actions with a loading state and spinner UI.
- Apply button spinner behavior to attribute, skill, item, damage, incapacitation, and remove-status card roll buttons to prevent duplicate actions and improve UX.
- Add CSS styles and animation for the button loading spinner.
- Normalize indentation and remove unused globals/comments in several script files.

Documentation:
- Update the changelog for version 5.22.0 with notes on button spinners and a modifier fix.