### PR TITLE
Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# Version 5.22.1
+* Chat now once again scrolls to the bottom for new messages
+* We now only apply vulnerable when it makes sense
+* Added a timeout to the roll spinner
+* Fixed raise damage when rerolling damage with a benny
+
 # Version 5.22.0
 * Vehicle items now use the vehicle's roll data when rolling damage. This basically does nothing at the moment but will fix an issue once the swade system is updated.
 * Fixed an issue when editing modifiers

--- a/scripts/brsw2-init.js
+++ b/scripts/brsw2-init.js
@@ -259,11 +259,13 @@ Hooks.on("renderChatMessageHTML", (message, html, _options) => {
 
         // Scroll the chat to the bottom if this is the last message
         if (game.messages.contents[game.messages.contents.length - 1] === message) {
-            const chat_bar = document.querySelector(".chat-log");
-            if (chat_bar) {
-                const rect = chat_bar.getBoundingClientRect();
-                if (chat_bar.scrollHeight - rect.height * 2 < chat_bar.scrollTop) {
-                    chat_bar.scrollTop = chat_bar.scrollHeight;
+            const chatScroll = document.querySelector(".chat-scroll");
+            if (chatScroll) {
+                const distanceFromBottom = chatScroll.scrollHeight - chatScroll.scrollTop - chatScroll.clientHeight;
+                if (distanceFromBottom < 600) {
+                    window.requestAnimationFrame(() => {
+                        chatScroll.scrollTop = chatScroll.scrollHeight;
+                    });
                 }
             }
         }

--- a/scripts/cards_common.js
+++ b/scripts/cards_common.js
@@ -1459,7 +1459,12 @@ export async function withButtonSpinner(button, action) {
     }
     addSpinnerToButton(button);
     try {
-        await action();
+        await Promise.race([
+            action(),
+            new Promise((_, reject) =>
+                setTimeout(() => reject(new Error("Operation timed out after 10 seconds")), 10_000)
+            )
+        ]);
     } finally {
         removeSpinnerFromButton(button);
     }

--- a/scripts/skill_card.js
+++ b/scripts/skill_card.js
@@ -351,6 +351,8 @@ export async function getTNFromToken(
     originToken = Utils.toTokenDoc(originToken);
     targetToken = Utils.toTokenDoc(targetToken);
 
+    const targetActor = targetToken.actor;
+
     const isFighting = Utils.isFightingSkill(skill);
     let useParryAsTN = isFighting;
     if (originToken) {
@@ -370,35 +372,45 @@ export async function getTNFromToken(
             );
         }
     }
+
     if (useParryAsTN) {
-        if (targetToken.actor.type !== "vehicle") {
+        if (targetActor.type !== "vehicle") {
             tn.reason = `${game.i18n.localize("SWADE.Parry")} - ${targetToken.name}`;
-            tn.value = parseInt(targetToken.actor.system.stats.parry.value);
+            tn.value = parseInt(targetActor.system.stats.parry.value);
         } else {
             await get_vehicle_tn(tn, targetToken);
         }
     }
+
     // Size modifiers
     if (shouldUseScale(originActor, targetToken, item, skill)) {
-        getScaleModifier(originActor, targetToken.actor, item, tn, extraData);
+        getScaleModifier(originActor, targetActor, item, tn, extraData);
     }
-    if (
-        targetToken.actor.system.status.isVulnerable ||
-        targetToken.actor.system.status.isStunned
-    ) {
-        tn.modifiers.push(
-            new TraitModifier(
-                `${targetToken.name}: ${game.i18n.localize("SWADE.Vuln")}`,
-                2,
-            ),
-        );
+
+    if (targetActor.system.status.isVulnerable && shouldApplyVulnerable(originToken, targetToken, item, skill)) {
+        tn.modifiers.push(new TraitModifier(`${targetToken.name}: ${game.i18n.localize("SWADE.Vuln")}`, 2));
     }
     return tn;
 }
 
-function shouldUseScale(origin_actor, targetToken, item, skill) {
-    if (!origin_actor || !targetToken) return false;
-    if (item?.system?.isVehicular || origin_actor.type === "vehicle") return false;
+function shouldApplyVulnerable(originToken, targetToken, item, skill) {
+    if (!originToken || !targetToken) return false;
+
+    //Can't be vulnerable to yourself
+    if (originToken.id === targetToken.id) return false;
+
+    if (!item) {
+        return Utils.isFightingSkill(skill) || Utils.isShootingSkill(skill) || Utils.isThrowingSkill(skill);
+    }
+
+    if (Utils.isWeaponOrBolt(item)) return true;
+
+    return false;
+}
+
+function shouldUseScale(originActor, targetToken, item, skill) {
+    if (!originActor || !targetToken) return false;
+    if (item?.system?.isVehicular || originActor.type === "vehicle") return false;
 
     if (!item) {
         return Utils.isFightingSkill(skill) || Utils.isShootingSkill(skill) || Utils.isThrowingSkill(skill);

--- a/templates/damage_partial.hbs
+++ b/templates/damage_partial.hbs
@@ -7,7 +7,7 @@
                 </span>
                 <span class="brsw-damage-roll-damage">
                     <span class="{{roll.extraClass}}" data-text="{{roll.damageResultText}}">{{roll.damageResultText}}</span>
-                    <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if roll.raise}}id="raise_roll" {{/if}}
+                    <button class="brsw-row-button brsw-damage-bennie-button brsw-form brsw-icon-button" {{#if ../raise}}id="raise_roll" {{/if}}
                             {{#if ../../bennie_available}}title="{{localize 'BRSW.Roll_and_bennie'}}" {{/if}} data-target="{{roll.target_id}}"
                             {{#unless ../../bennie_available}}disabled{{/unless}}>
                         <img src="{{{../../benny_image}}}" class="brsw-button-image" alt="Reroll with benny">


### PR DESCRIPTION
## Summary by Sourcery

Adjust combat targeting logic, chat scrolling behavior, and roll UI feedback to address edge cases and improve usability.

Bug Fixes:
- Avoid applying vulnerable status modifiers when targeting self or with non-weapon actions.
- Restore auto-scroll to the bottom of the chat log for new messages when the user is near the bottom.
- Ensure raise damage can be correctly rerolled with a benny by fixing the template condition.

Enhancements:
- Reuse a cached target actor reference when computing target numbers and scale modifiers.
- Limit the duration of the roll spinner by adding a 10-second timeout to long-running actions.

Documentation:
- Document the above fixes and improvements in the changelog for version 5.22.1.